### PR TITLE
[feat]: 장바구니 API 구현

### DIFF
--- a/src/assets/data/data.sql
+++ b/src/assets/data/data.sql
@@ -62,3 +62,8 @@ INSERT INTO cart_items (user_id, book_id, quantity) VALUES(1, 1, 2);
 SELECT b.id, b.title, b.summary, b.price, c.quantity 
 FROM cart_items AS c INNER JOIN books AS b ON c.book_id = b.id
 WHERE c.user_id = 3;
+
+-- 장바구니에서 선택한 물품 목록 조회
+SELECT b.id, b.title, b.summary, b.price, c.quantity 
+FROM cart_items AS c INNER JOIN books AS b ON c.book_id = b.id
+WHERE c.user_id = 3 AND c.id IN (1, 3);

--- a/src/routes/carts.js
+++ b/src/routes/carts.js
@@ -2,16 +2,10 @@ const express = require("express");
 const router = express.Router();
 router.use(express.json());
 
-const {
-  addTocart,
-  getCartItems,
-  removeFromCart,
-  getselectedItem,
-} = require("../controller/cartController");
+const { addTocart, getCartItems, removeFromCart } = require("../controller/cartController");
 
 router.post("/", addTocart);
 router.get("/", getCartItems);
 router.delete("/:bookId", removeFromCart);
-router.get("/items", getselectedItem);
 
 module.exports = router;


### PR DESCRIPTION
## 장바구니 API에 추가된 기능
- 장바구니에 담기
- 장바구니 목록 조회 
  - 장바구니 전체 목록 조회
  - 장바구니에서 선택한 물품들만 조회
<br/>

## 수정이 필요한 부분
- 로그인 성공한 회원에게 발급해준 access_token의 유효성을 검증하여, 요청을 보낸 회원을 검증하는 로직 구현 필요 
  - 임시로 user_id 값을 request의 body에서 추출 (단, 항상 인증된 회원의 user_id만 들어온다고  가정) 
  - 이후, request cookie에서 access_token을 추출하여 사용자 유효성 검증 진행할 예정

