### PR TITLE
[feat]: Refresh Token 도입, 로그아웃 기능 추가. [update]: 주문 요청 api 수정. [docs]: Readme.md 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
-# Book-Shop
+# 📖 Book Shop
+
+## 📂 프로젝트 소개
+
+**도서를 검색하고 구매가 가능한 가상의 온라인 도서 구매 사이트입니다. (진행중)**
+<br/>
+
+## 🌐 BackEnd
+
+### 💾 ERD 설계
+
+➡️ [ERD 설계 바로가기](https://www.notion.so/hongii/Project-2-Book-Shop-ERD-76e6b22f7f8d44769dd70b39a838ef4e)
+![ERD 설계](https://github.com/hongii/Book-Shop/assets/93701887/35c45945-5e30-4d90-a8c9-db59894ea4f0)
+
+</br>
+
+### 🏷️ API 명세
+
+➡️ [API 명세 바로가기](https://www.notion.so/hongii/Project-2-Book-Shop-API-cefc6edfc7bd4a19a748a6d1686ec379)
+
+</br>
+
+### ⚒️ Stacks
+
+#### Environment
+
+<img src="https://img.shields.io/badge/visual studio code-007ACC?style=for-the-badge&logo=visualstudiocode&logoColor=white">
+<img src="https://img.shields.io/badge/github-181717?style=for-the-badge&logo=github&logoColor=white">
+<img src="https://img.shields.io/badge/git-F05032?style=for-the-badge&logo=git&logoColor=white">
+
+#### Config
+
+<img src="https://img.shields.io/badge/npm-CB3837?style=for-the-badge&logo=npm&logoColor=white">
+
+#### Development
+
+<img src="https://img.shields.io/badge/node.js-339933?style=for-the-badge&logo=Node.js&logoColor=white">
+<img src="https://img.shields.io/badge/express-000000?style=for-the-badge&logo=express&logoColor=white">
+<img src="https://img.shields.io/badge/javascript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black">
+<img src="https://img.shields.io/badge/docker-2496ED?style=for-the-badge&logo=docker&logoColor=white">
+<img src="https://img.shields.io/badge/mariadb-003545?style=for-the-badge&logo=mariadb&logoColor=white">

--- a/src/controllers/booksController.js
+++ b/src/controllers/booksController.js
@@ -6,8 +6,8 @@ const { getBooksInfoService, getBookDetailService } = require("../services/books
 const getBooksInfo = async (req, res) => {
   let { category_id: categoryId, new: isNew, page, limit } = req.query;
 
-  const { data } = await getBooksInfoService(categoryId, isNew, page, limit);
-  return res.status(StatusCodes.OK).json({ data });
+  const { data, message } = await getBooksInfoService(categoryId, isNew, page, limit);
+  return res.status(StatusCodes.OK).json({ data, message });
 };
 
 /* 개별 도서 조회 */

--- a/src/controllers/cartsController.js
+++ b/src/controllers/cartsController.js
@@ -8,7 +8,7 @@ const {
 
 /* 장바구니에 담기 */
 const addTocart = async (req, res) => {
-  let { book_id: bookId, quantity } = req.body;
+  let { bookId, quantity } = req.body;
   const { id: userId } = req.user;
 
   const { message } = await addTocartService(bookId, quantity, userId);

--- a/src/controllers/cartsController.js
+++ b/src/controllers/cartsController.js
@@ -20,12 +20,8 @@ const getCartItems = async (req, res) => {
   const { selected: cartItemIds } = req.body;
   const { id: userId } = req.user;
 
-  const { data } = await getCartItemsService(cartItemIds, userId);
-  if (data) {
-    return res.status(StatusCodes.OK).json({ data });
-  }
-
-  return res.status(StatusCodes.NO_CONTENT).json();
+  const { data, message } = await getCartItemsService(cartItemIds, userId);
+  return res.status(StatusCodes.OK).json({ data, message });
 };
 
 /* 장바구니에서 물품 제거 */

--- a/src/controllers/categoriesController.js
+++ b/src/controllers/categoriesController.js
@@ -4,8 +4,8 @@ const { getAllCategoriesService } = require("../services/categoriesService");
 
 /* 카테고리 전체 목록 조회 */
 const getAllCategories = async (req, res) => {
-  const { data } = await getAllCategoriesService();
-  return res.status(StatusCodes.OK).json({ data });
+  const { data, message } = await getAllCategoriesService();
+  return res.status(StatusCodes.OK).json({ data, message });
 };
 
 module.exports = { getAllCategories: asyncWrapper(getAllCategories) };

--- a/src/controllers/likesController.js
+++ b/src/controllers/likesController.js
@@ -2,13 +2,21 @@ const { StatusCodes } = require("http-status-codes");
 const { asyncWrapper } = require("../middlewares/asyncWrapperMiddleware");
 const { likeAndUnlikeBookService } = require("../services/likesService");
 
+const RESPONSE_MESSAGES = {
+  LIKED: "좋아요 추가!",
+  UNLIKED: "좋아요 취소!",
+};
+
 /* 좋아요 추가 OR 취소 */
 const likeAndUnlikeBook = async (req, res) => {
   const { bookId } = req.params;
   const { id: userId } = req.user;
 
   const { data, message } = await likeAndUnlikeBookService(bookId, userId);
-  return res.status(StatusCodes.CREATED).json({ data, message });
+  if (message === RESPONSE_MESSAGES.LIKED) {
+    return res.status(StatusCodes.CREATED).json({ data, message });
+  }
+  return res.status(StatusCodes.OK).json({ data, message });
 };
 
 module.exports = { likeAndUnlikeBook: asyncWrapper(likeAndUnlikeBook) };

--- a/src/controllers/ordersController.js
+++ b/src/controllers/ordersController.js
@@ -26,11 +26,8 @@ const requestPayment = async (req, res) => {
 const getOrderList = async (req, res) => {
   const { id: userId } = req.user;
 
-  const { data } = await getOrderListService(userId);
-  if (data) {
-    return res.status(StatusCodes.OK).json({ data });
-  }
-  return res.status(StatusCodes.NO_CONTENT).json(); // 주문 내역 없는 경우
+  const { data, message } = await getOrderListService(userId);
+  return res.status(StatusCodes.OK).json({ data, message });
 };
 
 /* 주문 내역의 상품 상세 조회 */

--- a/src/controllers/usersController.js
+++ b/src/controllers/usersController.js
@@ -5,6 +5,7 @@ const {
   loginService,
   performPwdResetService,
   requestPwdResetService,
+  logoutService,
 } = require("../services/usersService");
 require("dotenv").config();
 
@@ -26,11 +27,29 @@ const login = async (req, res) => {
     httpOnly: true,
     secure: true,
     sameSite: "strict",
+    path: "/",
+    maxAge: 1000 * 60 * 60 * 24 * 14,
   });
 
   res.header("Authorization", `Bearer ${accessToken}`);
 
   return res.status(StatusCodes.OK).json({ data });
+};
+
+/* 로그아웃 */
+const logout = async (req, res) => {
+  const { id: userId } = req.user;
+  const { message } = await logoutService(userId);
+
+  res.cookie("refresh_token", "", {
+    httpOnly: true,
+    secure: true,
+    sameSite: "Strict",
+    path: "/",
+    maxAge: 0,
+  });
+  res.header("Authorization", "logout");
+  return res.status(StatusCodes.OK).json({ message });
 };
 
 /* 비밀번호 초기화 요청(로그인 하기 전, 비밀번호 찾기 기능) */
@@ -52,6 +71,7 @@ const performPwdReset = async (req, res) => {
 module.exports = {
   join: asyncWrapper(join),
   login: asyncWrapper(login),
+  logout: asyncWrapper(logout),
   requestPwdReset: asyncWrapper(requestPwdReset),
   performPwdReset: asyncWrapper(performPwdReset),
 };

--- a/src/controllers/usersController.js
+++ b/src/controllers/usersController.js
@@ -20,13 +20,14 @@ const join = async (req, res) => {
 const login = async (req, res) => {
   const { email, password } = req.body;
 
-  const { data, accessToken } = await loginService(email, password);
+  const { data, accessToken, refreshToken } = await loginService(email, password);
 
-  res.cookie("access_token", accessToken, {
+  res.cookie("refresh_token", refreshToken, {
     httpOnly: true,
     secure: true,
     sameSite: "strict",
-  }); // 추후 refresh token을 httpOnly 쿠키에 담아서 보낼 예정
+  });
+
   res.header("Authorization", `Bearer ${accessToken}`);
 
   return res.status(StatusCodes.OK).json({ data });

--- a/src/middlewares/authMiddleware.js
+++ b/src/middlewares/authMiddleware.js
@@ -39,9 +39,12 @@ const authenticateToken = async (req, res, next) => {
 };
 
 const refreshAccessToken = async (req, res, next) => {
+  const endPoint = req.originalUrl;
   const expired = req.expired;
   if (!expired) {
     return next();
+  } else if (endPoint === "/api/users/logout") {
+    return next(); // logout시에는 굳이 만료된 토큰을 재발급 받을 필요 없지 않을까
   }
 
   const { refresh_token: refreshToken } = req.cookies;
@@ -79,6 +82,8 @@ const refreshAccessToken = async (req, res, next) => {
         httpOnly: true,
         secure: true,
         sameSite: "strict",
+        path: "/",
+        maxAge: 1000 * 60 * 60 * 24 * 14, // 14일
       });
 
       /* 프론트 측에서는 서버로부터 받는 응답에서 매번 Authorization헤더를 확인해야한다. 

--- a/src/middlewares/authMiddleware.js
+++ b/src/middlewares/authMiddleware.js
@@ -1,13 +1,13 @@
 const { asyncWrapper } = require("../middlewares/asyncWrapperMiddleware");
 const { CustomError } = require("../middlewares/errorHandlerMiddleware");
 const { StatusCodes } = require("http-status-codes");
+const conn = require("../../database/mariadb").promise();
 const jwt = require("jsonwebtoken");
 const privateKey = process.env.PRIVATE_KEY;
 
 const authenticateToken = async (req, res, next) => {
-  const { access_token: accessToken } = req.cookies;
   const endPoint = req.originalUrl.slice(0, req.originalUrl.length - 2);
-  //const accessToken = req.headers.authorization && req.headers.authorization.split(" ")[1]; // 추후, 프론트단까지 구현완료되면 헤더에서 access token 값을 추출
+  const accessToken = req.headers.authorization && req.headers.authorization.split(" ")[1]; // 추후, 프론트단까지 구현완료되면 헤더에서 access token 값을 추출
   if (!accessToken) {
     if (endPoint === "/api/books") {
       // 개별 도서 조회 api에서 로그인하지 않는 사용자가 요청 보낸 경우에는 유효성 검증 pass시킴
@@ -22,11 +22,81 @@ const authenticateToken = async (req, res, next) => {
     }
   }
 
-  const { uid } = jwt.verify(accessToken, privateKey);
-  if (uid) {
+  try {
+    const { uid } = jwt.verify(accessToken, privateKey);
     req.user = { id: uid };
+    req.expired = false;
     return next();
+  } catch (err) {
+    if (err instanceof jwt.TokenExpiredError) {
+      const { uid } = jwt.decode(accessToken);
+      req.user = { id: uid };
+      req.expired = true;
+      return next();
+    }
+    next(err);
   }
 };
 
-module.exports = { authenticateToken: asyncWrapper(authenticateToken) };
+const refreshAccessToken = async (req, res, next) => {
+  const expired = req.expired;
+  if (!expired) {
+    return next();
+  }
+
+  const { refresh_token: refreshToken } = req.cookies;
+  if (!refreshToken) {
+    throw new CustomError(
+      "로그인(인증) 토큰이 만료되었습니다. 다시 로그인 후 사용해주세요.",
+      StatusCodes.UNAUTHORIZED,
+    );
+  }
+
+  const { id: userId } = req.user;
+  let sql = "SELECT * FROM users WHERE id=? AND refresh_token=?";
+  let values = [userId, refreshToken];
+  let [results] = await conn.query(sql, values);
+  if (results.length > 0) {
+    jwt.verify(refreshToken, privateKey);
+
+    const targetUser = results[0];
+    let newAccessToken = jwt.sign({ email: targetUser.email, uid: targetUser.id }, privateKey, {
+      expiresIn: process.env.ACCESSTOKEN_LIFETIME,
+      issuer: process.env.ACCESSTOKEN_ISSUER,
+    });
+
+    let newRefreshToken = jwt.sign({ uid: targetUser.id }, privateKey, {
+      expiresIn: process.env.REFRESHTOKEN_LIFETIME,
+      issuer: process.env.REFRESHTOKEN_ISSUER,
+    });
+
+    sql = "UPDATE users SET refresh_token=? WHERE id=?";
+    values = [newRefreshToken, targetUser.id];
+    [results] = await conn.query(sql, values);
+
+    if (results.affectedRows > 0) {
+      res.cookie("refresh_token", newRefreshToken, {
+        httpOnly: true,
+        secure: true,
+        sameSite: "strict",
+      });
+
+      /* 프론트 측에서는 서버로부터 받는 응답에서 매번 Authorization헤더를 확인해야한다. 
+      만약 Authorization헤더에 값이 없다면 기존의 accesstoken이 유효하다고 판단하면 되고 
+      Authorization헤더에 값이 있다면, 서버측에서 기존 accesstoken이 만료되어 새롭게 발급해준 access token이라고 간주하고 
+      private변수에 새롭게 발급받은 access token을 다시 저장하면 된다.*/
+      res.header("Authorization", `Bearer ${newAccessToken}`);
+      return next();
+    }
+  }
+  throw new CustomError(
+    "refresh token정보가 일치하지 않습니다. 다시 로그인 후 사용해주세요.",
+    StatusCodes.FORBIDDEN,
+  );
+  // 프론트에서는 401 또는 403 응답을 받으면 로그인 페이지로 이동 시키기(재로그인)
+};
+
+module.exports = {
+  authenticateToken: asyncWrapper(authenticateToken),
+  refreshAccessToken: asyncWrapper(refreshAccessToken),
+};

--- a/src/middlewares/authMiddleware.js
+++ b/src/middlewares/authMiddleware.js
@@ -7,12 +7,9 @@ const privateKey = process.env.PRIVATE_KEY;
 
 const authenticateToken = async (req, res, next) => {
   const endPoint = req.originalUrl.slice(0, req.originalUrl.length - 2);
-  const accessToken = req.headers.authorization && req.headers.authorization.split(" ")[1]; // 추후, 프론트단까지 구현완료되면 헤더에서 access token 값을 추출
+  const accessToken = req.headers.authorization && req.headers.authorization.split(" ")[1];
   if (!accessToken) {
     if (endPoint === "/api/books") {
-      // 개별 도서 조회 api에서 로그인하지 않는 사용자가 요청 보낸 경우에는 유효성 검증 pass시킴
-      /* 개별 도서 조회 api에서 로그인한 유저일 경우, 해당 도서를 좋아요 눌렀는지 여부(is_liked)를 sql쿼리 결과로 받아오고,
-        로그인하지 않은 유저일 경우, 해당 도서를 좋아요 눌렀는지 여부(is_liked)를 그냥 false로 설정함 */
       return next();
     } else {
       throw new CustomError(ERROR_MESSAGES.LOGIN_REQUIRED, StatusCodes.UNAUTHORIZED);
@@ -81,17 +78,12 @@ const refreshAccessToken = async (req, res, next) => {
         maxAge: 1000 * 60 * 60 * 24 * 14, // 14일
       });
 
-      /* 프론트 측에서는 서버로부터 받는 응답에서 매번 Authorization헤더를 확인해야한다. 
-      만약 Authorization헤더에 값이 없다면 기존의 accesstoken이 유효하다고 판단하면 되고 
-      Authorization헤더에 값이 있다면, 서버측에서 기존 accesstoken이 만료되어 새롭게 발급해준 access token이라고 간주하고 
-      private변수에 새롭게 발급받은 access token을 다시 저장하면 된다.*/
       res.header("Authorization", `Bearer ${newAccessToken}`);
       console.log("Access token refreshed.");
       return next();
     }
   }
   throw new CustomError(ERROR_MESSAGES.REFRESH_TOKEN_MISMATCH, StatusCodes.UNAUTHORIZED);
-  // 프론트에서는 401응답을 받으면 로그인 페이지로 이동 시키기(재로그인)
 };
 
 module.exports = {

--- a/src/middlewares/errorHandlerMiddleware.js
+++ b/src/middlewares/errorHandlerMiddleware.js
@@ -1,6 +1,22 @@
 const { StatusCodes, getReasonPhrase } = require("http-status-codes");
 const { TokenExpiredError, JsonWebTokenError } = require("jsonwebtoken");
 
+const ERROR_MESSAGES = {
+  BAD_REQUEST: "잘못된 요청입니다. 확인 후 다시 시도해주세요.",
+  SERVER_ERROR: "서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요.",
+  NOT_FOUND: "존재하지 않는 페이지입니다.",
+  TOKEN_EXPIRED: "로그인(인증) 토큰이 만료되었습니다. 다시 로그인 후 사용해주세요.",
+  INVALID_TOKEN: "유효하지 않은 토큰입니다.",
+  LOGIN_REQUIRED: "로그인이 필요합니다. 로그인 후 이용해주세요.",
+  REFRESH_TOKEN_MISMATCH: "refresh token정보가 일치하지 않습니다. 다시 로그인 후 사용해주세요.",
+  BOOKS_NOT_FOUND: "존재하지 않는 도서입니다.",
+  ORDER_ERROR: "결제 진행 중 오류가 발생했습니다.",
+  DUPLICATE_EMAIL: "이미 가입된 이메일입니다. 다른 이메일을 입력해주세요.",
+  LOGIN_UNAUTHORIZED: "로그인 도중에 문제가 생겼습니다. 로그인을 다시 시도해주세요.",
+  LOGIN_BAD_REQUEST: "이메일 또는 비밀번호를 잘못 입력했습니다. 입력하신 내용을 다시 확인해주세요.",
+  EMAIL_NOT_FOUND: "존재하지 않는 이메일입니다. 가입한 이메일 정보를 정확히 입력해주세요.",
+};
+
 class CustomError extends Error {
   constructor(errorMessages, statusCode, multiErrMsg = false) {
     const message = Array.isArray(errorMessages) ? errorMessages.join(", ") : String(errorMessages);
@@ -22,22 +38,22 @@ const handleCustomError = (err, res) => {
 
 const handleTokenExpiredError = (res) => {
   return res.status(StatusCodes.UNAUTHORIZED).json({
-    message: "로그인(인증) 토큰이 만료되었습니다. 다시 로그인 후 사용해주세요.",
+    message: ERROR_MESSAGES.TOKEN_EXPIRED,
   });
 };
 
 const handleJsonWebTokenError = (res) =>
-  res.status(StatusCodes.FORBIDDEN).json({ message: "유효하지 않은 토큰입니다." });
+  res.status(StatusCodes.FORBIDDEN).json({ message: ERROR_MESSAGES.INVALID_TOKEN });
 
 const handleSQLError = (res) => {
   return res.status(StatusCodes.BAD_REQUEST).json({
-    message: "잘못된 요청입니다. 확인 후 다시 시도해주세요.",
+    message: ERROR_MESSAGES.BAD_REQUEST,
   });
 };
 
 const handleServerError = (res) => {
   return res.status(StatusCodes.BAD_REQUEST).json({
-    message: "서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요.",
+    message: ERROR_MESSAGES.SERVER_ERROR,
   });
 };
 
@@ -59,8 +75,8 @@ const errorHandler = (err, req, res, next) => {
 
 const handleNotFound = (req, res) => {
   return res.status(StatusCodes.NOT_FOUND).json({
-    message: "요청한 경로를 찾을 수 없습니다.",
+    message: ERROR_MESSAGES.NOT_FOUND,
   });
 };
 
-module.exports = { CustomError, errorHandler, handleNotFound };
+module.exports = { CustomError, errorHandler, handleNotFound, ERROR_MESSAGES };

--- a/src/middlewares/validateMiddleware.js
+++ b/src/middlewares/validateMiddleware.js
@@ -132,7 +132,6 @@ const validateChainIntArr = (path) => {
     .withMessage(`${path}의 데이터 형식이 틀렸습니다.`);
 };
 
-// 주문api의 items
 const validateChainObjArr = (path) => {
   return body(path)
     .isArray({ min: 1 })

--- a/src/middlewares/validateMiddleware.js
+++ b/src/middlewares/validateMiddleware.js
@@ -96,7 +96,9 @@ const validateChainIsString = (location, path, opt = false) => {
   if (opt) locationMethod = locationMethod.optional();
 
   return locationMethod
-    .isString()
+    .custom((str) => {
+      return str && typeof str === "string" && str.trim().length > 0;
+    })
     .withMessage(`${location}의 ${path}는 ${opt ? "" : "필수 정보이며 "}string타입이어야 합니다.`);
 };
 
@@ -109,8 +111,11 @@ const validateChainStringObj = (path) => {
         obj.hasOwnProperty("receiver") &&
         obj.hasOwnProperty("contact") &&
         typeof obj.address === "string" &&
+        obj.address.trim().length > 0 &&
         typeof obj.receiver === "string" &&
-        typeof obj.contact === "string"
+        obj.receiver.trim().length > 0 &&
+        typeof obj.contact === "string" &&
+        obj.contact.trim().length > 0
       );
     })
     .withMessage(`${path}의 데이터 형식이 틀렸습니다.`);
@@ -139,7 +144,9 @@ const validateChainObjArr = (path) => {
           obj.hasOwnProperty("bookId") &&
           obj.hasOwnProperty("quantity") &&
           Number.isInteger(obj.cartItemId) &&
+          obj.cartItemId > 0 &&
           Number.isInteger(obj.bookId) &&
+          obj.bookId > 0 &&
           Number.isInteger(obj.quantity),
       );
     })

--- a/src/routes/books.js
+++ b/src/routes/books.js
@@ -1,11 +1,11 @@
 const express = require("express");
 const router = express.Router();
 
-const { authenticateToken } = require("../middlewares/authMiddleware");
+const { authenticateToken, refreshAccessToken } = require("../middlewares/authMiddleware");
 const { validateGetBooks, validateGetBookDetail } = require("../middlewares/validateMiddleware");
 const { getBooksInfo, getBookDetail } = require("../controllers/booksController");
 
 router.get("/", validateGetBooks, getBooksInfo);
-router.get("/:bookId", validateGetBookDetail, authenticateToken, getBookDetail);
+router.get("/:bookId", validateGetBookDetail, authenticateToken, refreshAccessToken, getBookDetail);
 
 module.exports = router;

--- a/src/routes/carts.js
+++ b/src/routes/carts.js
@@ -6,10 +6,10 @@ const {
   validateGetCartItems,
   validateRemoveFromCart,
 } = require("../middlewares/validateMiddleware");
-const { authenticateToken } = require("../middlewares/authMiddleware");
+const { authenticateToken, refreshAccessToken } = require("../middlewares/authMiddleware");
 const { addTocart, getCartItems, removeFromCart } = require("../controllers/cartsController");
 
-router.use(authenticateToken);
+router.use(authenticateToken, refreshAccessToken);
 
 router.post("/", validateGetAddToCart, addTocart);
 router.get("/", validateGetCartItems, getCartItems);

--- a/src/routes/likes.js
+++ b/src/routes/likes.js
@@ -1,11 +1,11 @@
 const express = require("express");
 const router = express.Router();
 
-const { authenticateToken } = require("../middlewares/authMiddleware");
+const { authenticateToken, refreshAccessToken } = require("../middlewares/authMiddleware");
 const { likeAndUnlikeBook } = require("../controllers/likesController");
 const { validateLikeAndUnlikeBook } = require("../middlewares/validateMiddleware");
 
-router.use(authenticateToken);
+router.use(authenticateToken, refreshAccessToken);
 
 router.post("/:bookId", validateLikeAndUnlikeBook, likeAndUnlikeBook);
 // router.delete("/:bookId", authenticateToken, likeAndUnlikeBook);

--- a/src/routes/orders.js
+++ b/src/routes/orders.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const router = express.Router();
 
+const { authenticateToken, refreshAccessToken } = require("../middlewares/authMiddleware");
 const {
   validateRequestPayment,
   validateGetOrderListDetails,
@@ -10,9 +11,8 @@ const {
   getOrderList,
   getOrderListDetails,
 } = require("../controllers/ordersController");
-const { authenticateToken } = require("../middlewares/authMiddleware");
 
-router.use(authenticateToken);
+router.use(authenticateToken, refreshAccessToken);
 
 router.post("/", validateRequestPayment, requestPayment);
 router.get("/", getOrderList);

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -1,17 +1,24 @@
 const express = require("express");
 const router = express.Router();
 
-const { body } = require("express-validator");
-const { join, login, requestPwdReset, performPwdReset } = require("../controllers/usersController");
+const { authenticateToken, refreshAccessToken } = require("../middlewares/authMiddleware");
 const {
   validateJoin,
   validateLogin,
   validateRequestResetPW,
   validateResetPW,
 } = require("../middlewares/validateMiddleware");
+const {
+  join,
+  login,
+  logout,
+  requestPwdReset,
+  performPwdReset,
+} = require("../controllers/usersController");
 
 router.post("/join", validateJoin, join);
 router.post("/login", validateLogin, login);
+router.post("/logout", authenticateToken, refreshAccessToken, logout);
 router.post("/reset", validateRequestResetPW, requestPwdReset);
 router.put("/reset", validateResetPW, performPwdReset);
 

--- a/src/services/booksService.js
+++ b/src/services/booksService.js
@@ -9,7 +9,7 @@ const RESPONSE_MESSAGES = {
 };
 
 const getBooksInfoService = async (categoryId, isNew, page, limit) => {
-  // 아래 변수들의 default값은 전체 도서 목록 조회 기준
+  // 전체 도서 목록 조회
   limit = parseInt(limit);
   let offset = (+page - 1) * limit;
   let sql = `SELECT b.*, c.category_name,

--- a/src/services/cartsService.js
+++ b/src/services/cartsService.js
@@ -1,7 +1,12 @@
 const conn = require("../../database/mariadb").promise();
 const { StatusCodes } = require("http-status-codes");
 const { snakeToCamelData } = require("../utils/convertSnakeToCamel");
-const { CustomError } = require("../middlewares/errorHandlerMiddleware");
+const { CustomError, ERROR_MESSAGES } = require("../middlewares/errorHandlerMiddleware");
+
+const RESPONSE_MESSAGES = {
+  ADD_TO_CART: "장바구니에 추가되었습니다.",
+  EMPTY_CART: "장바구니 목록이 비어있습니다.",
+};
 
 const addTocartService = async (bookId, quantity, userId) => {
   let sql = "SELECT * FROM books WHERE id=?";
@@ -19,14 +24,15 @@ const addTocartService = async (bookId, quantity, userId) => {
       // 없다면 데이터 그대로 삽입
       sql = "INSERT INTO cart_items (quantity, user_id, book_id) VALUES(?, ?, ?)";
     }
+
     values = [+quantity, +userId, +bookId];
-    await conn.query(sql, values);
-    return { message: "장바구니에 추가되었습니다." };
+    [results] = await conn.query(sql, values);
+    if (results.affectedRows > 0) {
+      return { message: RESPONSE_MESSAGES.ADD_TO_CART };
+    }
+    throw new CustomError(ERROR_MESSAGES.BAD_REQUEST, StatusCodes.BAD_REQUEST);
   }
-  throw new CustomError(
-    "해당 도서 id는 존재하지 않습니다. 확인 후 다시 입력해주세요.",
-    StatusCodes.NOT_FOUND,
-  );
+  throw new CustomError(ERROR_MESSAGES.BOOKS_NOT_FOUND, StatusCodes.NOT_FOUND);
 };
 
 const getCartItemsService = async (cartItemIds, userId) => {
@@ -41,20 +47,20 @@ const getCartItemsService = async (cartItemIds, userId) => {
     /* 장바구니에서 선택한 물품 목록(주문 예상 물품 목록) 조회 */
     values.push(cartItemIds);
 
-    const [results] = await conn.query(sql + tailSql, values);
-    if (results.length === cartItemIds.length) {
-      const items = snakeToCamelData(results);
-      return { data: { items } };
+    const [selectedItemsResults] = await conn.query(sql + tailSql, values);
+    if (selectedItemsResults.length === cartItemIds.length) {
+      const items = snakeToCamelData(selectedItemsResults);
+      return { data: { items }, message: null };
     }
-    throw new CustomError("잘못된 요청입니다. 확인 후 다시 시도해주세요.", StatusCodes.BAD_REQUEST);
+    throw new CustomError(ERROR_MESSAGES.BAD_REQUEST, StatusCodes.BAD_REQUEST);
   }
 
-  const [selectedItemsResults] = await conn.query(sql, values);
-  if (selectedItemsResults.length > 0) {
-    const items = snakeToCamelData(selectedItemsResults);
-    return { data: { items } };
+  const [results] = await conn.query(sql, values);
+  if (results.length > 0) {
+    const items = snakeToCamelData(results);
+    return { data: { items }, message: null };
   }
-  return { data: null };
+  return { data: {}, message: RESPONSE_MESSAGES.EMPTY_CART };
 };
 
 const removeFromCartService = async (bookId, userId) => {
@@ -64,10 +70,7 @@ const removeFromCartService = async (bookId, userId) => {
   if (results.affectedRows > 0) {
     return null;
   }
-  throw new CustomError(
-    "장바구니에 해당 도서가 담겨있지 않습니다. 다시 입력해주세요.",
-    StatusCodes.NOT_FOUND,
-  );
+  throw new CustomError(ERROR_MESSAGES.BAD_REQUEST, StatusCodes.BAD_REQUEST);
 };
 
 module.exports = {

--- a/src/services/cartsService.js
+++ b/src/services/cartsService.js
@@ -36,7 +36,7 @@ const addTocartService = async (bookId, quantity, userId) => {
 };
 
 const getCartItemsService = async (cartItemIds, userId) => {
-  /* 장바구니 전체 목록 조회 */
+  // 장바구니 전체 목록 조회
   let sql = `SELECT c.id AS cart_item_id, c.book_id, b.title, b.summary, b.price, c.quantity 
               FROM cart_items AS c INNER JOIN books AS b ON c.book_id = b.id 
               WHERE c.user_id=?`;
@@ -44,7 +44,7 @@ const getCartItemsService = async (cartItemIds, userId) => {
   let values = [+userId];
 
   if (cartItemIds) {
-    /* 장바구니에서 선택한 물품 목록(주문 예상 물품 목록) 조회 */
+    // 장바구니에서 선택한 물품 목록(주문 예상 물품 목록) 조회
     values.push(cartItemIds);
 
     const [selectedItemsResults] = await conn.query(sql + tailSql, values);

--- a/src/services/cartsService.js
+++ b/src/services/cartsService.js
@@ -10,12 +10,12 @@ const RESPONSE_MESSAGES = {
 
 const addTocartService = async (bookId, quantity, userId) => {
   let sql = "SELECT * FROM books WHERE id=?";
-  const [results] = await conn.query(sql, bookId);
+  let [results] = await conn.query(sql, [+bookId]);
   if (results.length > 0) {
     // 동일한 물품이 장바구니에 존재하는지 확인
     sql = "SELECT * FROM cart_items WHERE user_id=? AND book_id=?";
     let values = [+userId, +bookId];
-    const [results] = await conn.query(sql, values);
+    [results] = await conn.query(sql, values);
     if (results.length > 0) {
       // 동일한 물품이 있다면 수량만 수정함
       quantity = parseInt(quantity) + results[0].quantity;

--- a/src/services/categoriesService.js
+++ b/src/services/categoriesService.js
@@ -1,16 +1,18 @@
 const conn = require("../../database/mariadb").promise();
-const { StatusCodes } = require("http-status-codes");
 const { snakeToCamelData } = require("../utils/convertSnakeToCamel");
-const { CustomError } = require("../middlewares/errorHandlerMiddleware");
+
+const RESPONSE_MESSAGES = {
+  EMPTY_CATEGORY_LIST: "카테고리 목록이 비어있습니다.",
+};
 
 const getAllCategoriesService = async () => {
   const sql = `SELECT * FROM categories`;
   const [results] = await conn.query(sql);
   if (results.length > 0) {
     const categories = snakeToCamelData(results);
-    return { data: { categories } };
+    return { data: { categories }, message: null };
   }
-  throw new CustomError("조회 가능한 도서가 없습니다.", StatusCodes.NOT_FOUND);
+  return { data: {}, message: RESPONSE_MESSAGES.EMPTY_CATEGORY_LIST };
 };
 
 module.exports = { getAllCategoriesService };

--- a/src/services/likesService.js
+++ b/src/services/likesService.js
@@ -2,6 +2,11 @@ const conn = require("../../database/mariadb").promise();
 const { StatusCodes } = require("http-status-codes");
 const { CustomError } = require("../middlewares/errorHandlerMiddleware");
 
+const RESPONSE_MESSAGES = {
+  LIKED: "좋아요 추가!",
+  UNLIKED: "좋아요 취소!",
+};
+
 const likeAndUnlikeBookService = async (bookId, userId) => {
   let sql = "SELECT * FROM likes WHERE user_id=? AND liked_book_id=?";
   let values = [+userId, +bookId];
@@ -11,29 +16,26 @@ const likeAndUnlikeBookService = async (bookId, userId) => {
     sql = "DELETE FROM likes WHERE user_id=? AND liked_book_id=?";
     values = [+userId, +bookId];
     [results] = await conn.query(sql, values);
-    if (results.affectedRows > 0) {
+    if (results.affectedRows === 1) {
       sql = `SELECT COUNT(*) AS likes FROM likes WHERE liked_book_id = ?`;
       const [getLikesResults] = await conn.query(sql, +bookId);
       let likes = getLikesResults[0].likes;
-      return { data: { likes }, message: "좋아요 취소!" };
+      return { data: { likes }, message: RESPONSE_MESSAGES.UNLIKED };
     }
   } else {
     // 사용자가 해당 도서를 "좋아요" 해두지 않은 경우 -> 좋아요 추가
     sql = "INSERT INTO likes(user_id, liked_book_id) VALUES(?,  ?);";
     values = [+userId, +bookId];
     [results] = await conn.query(sql, values);
-    if (results.affectedRows > 0) {
+    if (results.affectedRows === 1) {
       sql = `SELECT COUNT(*) AS likes FROM likes WHERE liked_book_id = ?`;
       const [getLikesResults] = await conn.query(sql, +bookId);
       let likes = getLikesResults[0].likes;
-      return { data: { likes }, message: "좋아요 추가!" };
+      return { data: { likes }, message: RESPONSE_MESSAGES.LIKED };
     }
   }
 
-  throw new CustomError(
-    "잘못된 정보를 입력하였습니다. 확인 후 다시 입력해주세요.",
-    StatusCodes.BAD_REQUEST,
-  );
+  throw new CustomError(ERROR_MESSAGES.BAD_REQUEST, StatusCodes.BAD_REQUEST);
 };
 
 module.exports = { likeAndUnlikeBookService };

--- a/src/services/ordersService.js
+++ b/src/services/ordersService.js
@@ -16,42 +16,76 @@ const requestPaymentService = async (
   mainBookTitle,
   userId,
 ) => {
-  // 트랜잭션 시작
-  await conn.beginTransaction();
+  try {
+    // 트랜잭션 시작
+    await conn.beginTransaction();
 
-  let sql = "INSERT INTO deliveries (address, receiver, contact) VALUES(?, ?, ?)";
-  let values = [delivery.address, delivery.receiver, delivery.contact];
-  const [insertDeliveriesResults] = await conn.query(sql, values);
+    // DB의 cart_items 담긴 정보와 요청 받은 정보가 일치하는지 확인하는 작업 선행
+    let sql = `SELECT * FROM cart_items WHERE id IN (?)`;
+    const itemIds = items.map((obj) => obj.cartItemId);
+    const [checkResults] = await conn.query(sql, [itemIds]);
+    if (checkResults.length === itemIds.length) {
+      const requestItems = [];
+      items.sort((obj1, obj2) => obj1.cartItemId - obj2.cartItemId);
+      for (let i = 0; i < items.length; i++) {
+        requestItems.push([items[i].cartItemId, userId, items[i].bookId, items[i].quantity]);
+      }
 
-  const deliveryId = insertDeliveriesResults?.insertId;
-  sql = `INSERT INTO orders (delivery_id, user_id, main_book_title, total_price, total_quantity) 
+      for (let i = 0; i < itemIds.length; i++) {
+        if (
+          checkResults[i].id !== requestItems[i][0] ||
+          checkResults[i].user_id !== requestItems[i][1] ||
+          checkResults[i].book_id !== requestItems[i][2] ||
+          checkResults[i].quantity !== requestItems[i][3]
+        ) {
+          throw new CustomError(" (장바구니 정보와 일치하지 않습니다.)", StatusCodes.BAD_REQUEST);
+        }
+      }
+
+      sql = `INSERT INTO deliveries (address, receiver, contact) VALUES(?, ?, ?)`;
+      values = [delivery.address, delivery.receiver, delivery.contact];
+      const [insertDeliveriesResults] = await conn.query(sql, values);
+
+      const deliveryId = insertDeliveriesResults?.insertId;
+      sql = `INSERT INTO orders (delivery_id, user_id, main_book_title, total_price, total_quantity) 
               VALUES(?, ?, ?, ?, ?)`;
-  values = [deliveryId, userId, mainBookTitle, totalPrice, totalQuantity];
-  const [insertOrdersResults] = await conn.query(sql, values);
+      values = [deliveryId, userId, mainBookTitle, totalPrice, totalQuantity];
+      const [insertOrdersResults] = await conn.query(sql, values);
 
-  const orderId = insertOrdersResults?.insertId;
-  sql = `INSERT INTO ordered_books (order_id, book_id, quantity) VALUES ?`; // MULTI-INSERT
-  values = [];
-  for (let i = 0; i < items.length; i++) {
-    values.push([orderId, items[i].bookId, items[i].quantity]);
-  }
-  const [insertOrederedBookresults] = await conn.query(sql, [values]);
-  if (insertOrederedBookresults.affectedRows === 0) {
+      const orderId = insertOrdersResults?.insertId;
+      sql = `INSERT INTO ordered_books (order_id, book_id, quantity) VALUES ?`; // MULTI-INSERT
+      values = [];
+      for (let i = 0; i < items.length; i++) {
+        values.push([orderId, items[i].bookId, items[i].quantity]);
+      }
+      const [insertOrederedBookresults] = await conn.query(sql, [values]);
+      if (insertOrederedBookresults.affectedRows === 0) {
+        await conn.rollback(); // 트랜잭션 롤백
+        throw new CustomError(ERROR_MESSAGES.ORDER_ERROR, StatusCodes.BAD_REQUEST);
+      }
+
+      // 주문한 상품은 장바구니에서 삭제하기
+      sql = "DELETE FROM cart_items WHERE id IN(?)";
+      const [deleteResults] = await conn.query(sql, [itemIds]);
+      if (deleteResults.affectedRows !== items.length) {
+        await conn.rollback(); // 트랜잭션 롤백
+        throw new CustomError(ERROR_MESSAGES.ORDER_ERROR, StatusCodes.BAD_REQUEST);
+      }
+
+      // 트랜잭션 커밋 완료
+      await conn.commit();
+      return { message: RESPONSE_MESSAGES.ORDER_SUCCESS };
+    }
+    throw new CustomError(ERROR_MESSAGES.ORDER_ERROR, StatusCodes.BAD_REQUEST);
+  } catch (err) {
     await conn.rollback(); // 트랜잭션 롤백
+    if (err.message !== ERROR_MESSAGES.ORDER_ERROR) {
+      err.message = ERROR_MESSAGES.ORDER_ERROR + err.message;
+      throw new CustomError(err.message, StatusCodes.BAD_REQUEST);
+    }
+
     throw new CustomError(ERROR_MESSAGES.ORDER_ERROR, StatusCodes.BAD_REQUEST);
   }
-  // 주문한 상품은 장바구니에서 삭제하기
-  const itemIds = items.map((obj) => obj.cartItemId);
-  sql = "DELETE FROM cart_items WHERE id IN(?)";
-  const [deleteResults] = await conn.query(sql, [itemIds]);
-  if (deleteResults.affectedRows !== items.length) {
-    await conn.rollback(); // 트랜잭션 롤백
-    throw new CustomError(ERROR_MESSAGES.ORDER_ERROR, StatusCodes.BAD_REQUEST);
-  }
-
-  // 트랜잭션 커밋 완료
-  await conn.commit();
-  return { message: RESPONSE_MESSAGES.ORDER_SUCCESS };
 };
 
 const getOrderListService = async (userId) => {

--- a/src/services/usersService.js
+++ b/src/services/usersService.js
@@ -11,6 +11,7 @@ const RESPONSE_MESSAGES = {
   LOGOUT_SUCCESS: "로그아웃 되었습니다.",
   RESET_PASSWORD: "비밀번호가 변경되었습니다.",
 };
+
 const joinService = async (email, password, name, contact) => {
   // 새로운 회원 데이터 넣기 전에 이미 가입된 회원인지 아닌지 확인
   let sql = `SELECT * FROM users WHERE email = ?`;
@@ -102,7 +103,6 @@ const requestPwdResetService = async (email) => {
 
 /* 비밀번호 초기화(새로운 비밀번호로 변경하는 기능) */
 const performPwdResetService = async (email, newPW) => {
-  // .EMAIL_NOT_FOUND비밀번호 암호화
   const salt = crypto.randomBytes(32).toString("base64");
   const hashPassword = crypto.pbkdf2Sync(newPW, salt, 10000, 32, "sha512").toString("base64");
 

--- a/src/services/usersService.js
+++ b/src/services/usersService.js
@@ -48,6 +48,7 @@ const loginService = async (email, password) => {
         issuer: process.env.ACCESSTOKEN_ISSUER,
       });
 
+      // const refreshTokenExp = Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 14; //14일
       let refreshToken = jwt.sign({ uid: targetUser.id }, privateKey, {
         expiresIn: process.env.REFRESHTOKEN_LIFETIME,
         issuer: process.env.REFRESHTOKEN_ISSUER,
@@ -75,6 +76,17 @@ const loginService = async (email, password) => {
     "이메일 또는 비밀번호를 잘못 입력했습니다. 입력하신 내용을 다시 확인해주세요.",
     StatusCodes.BAD_REQUEST,
   );
+};
+
+const logoutService = async (userId) => {
+  const sql = `UPDATE users SET refresh_token=? WHERE id=?`;
+  const values = ["", userId];
+  const [results] = await conn.query(sql, values);
+  if (results.affectedRows === 1) {
+    return { message: "로그아웃 되었습니다." };
+  }
+
+  throw new CustomError("잘못된 요청입니다. 확인 후 다시 시도해주세요.", StatusCodes.BAD_REQUEST);
 };
 
 /* 비밀번호 초기화 요청(로그인 하기 전, 비밀번호 찾기 기능) */
@@ -108,4 +120,10 @@ const performPwdResetService = async (email, newPW) => {
   throw new CustomError("잘못된 요청입니다. 확인 후 다시 시도해주세요.", StatusCodes.BAD_REQUEST);
 };
 
-module.exports = { joinService, loginService, requestPwdResetService, performPwdResetService };
+module.exports = {
+  joinService,
+  loginService,
+  logoutService,
+  requestPwdResetService,
+  performPwdResetService,
+};


### PR DESCRIPTION
## 추가 기능
### 1) Refresh Token의 도입 & 자동 로그인 연장
- DB : users 테이블에 refresh_token 컬럼 추가
- login 성공할 경우,
  - access token을 발급하고 access token을 Authorization Bearer 헤더에 담아서 전송
  - refresh token을 발급하고 users 테이블에 refresh_token 컬럼에 저장한 후 httpOnly cookie에 담아서 전송
- 인증이 선행되어야 하는 요청의 경우, request 객체의 헤더에 담긴 access token의 유효성 검증을 진행한다.
  - access token이 만료된 경우, cookie에 담겨진 refresh token을 추출하여 DB에 저장된 값과 일치하는지 확인 후, 유효성 검증 진행
     1. 유효성 검증에 통과되면 새로운 access token과 refresh token을 발급하여 각각 response객체의 Authorization헤더와 httpOnly cookie에 담아서 다음 미들웨어로 이동
     2. refresh token이 유효성 검증에 통과되지 않을 경우 에러 핸들러 미들웨어로 이동
  - access token이 유효하지 않은 토큰이거나 DB에 저장된 값과 일치하지 않을 경우, 에러 핸들러 미들웨어로 이동

- cf) 프론트 측 처리 시나리오
  - 프론트 측에서는 인증이 필요한 요청을 보낼 경우, 매번 res객체의 Authorization헤더를 확인해야 한다.
    - access token이 만료되었고 refresh token검증에 통과한 경우, 새롭게 발급된 access token 정보를 추출하기 위해 (자동 로그인 연장으로 구현)
  - 프론트 측에서는 401 에러의 경우, 로그인 페이지로 이동시키도록 한다.

### 2) 로그아웃 API 생성
- 로그아웃 api 호출 시, cookie에 저장되어 있는 Refresh Token을 삭제 & DB의 users테이블 refresh_token에 저장되어 있던 해당 사용자의 Refresh Token값 제거(=빈 문자열)  

<br/>

## 변경 사항
### 1) 주문 요청 API 
- Transaction 코드 수정
  - 문제 상황 : 주문 요청 api의 라우터 미들웨어(=컨트롤러)는 asyncWrraper로 감싸진 미들웨어인데, 이 미들웨어 내부의 catch문에서는 rollback을 수행하지 않음
    - 따라서, 주문 과정에서 CustomError이외의 에러가 발생한 경우, rollback을 할 수 없는 문제가 발생
  - 해결 방법 : 주문 api는 트랜잭션의 원활한 동작을 위해 try-catch문으로 감싸주었고, catch문에서 rollback을 시킨후, 에러 핸들러 미들웨어로 이동시키도록 수정함
- DB의 cart_items 테이블에 저장 되어있는 데이터와 주문 요청 받은 총 수량 정보가 일치하는지 확인하는 sql구문 추가

### 2) Error Messge와 Response Message를 재사용할 수 있도록 수정

### 3) Readme파일 작성

