### PR TITLE
[refactor]: 모든 API의 Controller와 Service코드 리팩토링, 중복코드 제거하고 유틸함수 생성

### DIFF
--- a/src/controllers/booksController.js
+++ b/src/controllers/booksController.js
@@ -4,9 +4,9 @@ const { getBooksInfoService, getBookDetailService } = require("../services/books
 
 /* 도서 목록 조회 */
 const getBooksInfo = async (req, res) => {
-  let { category_id: categoryId, new: isNew, page, limit } = req.query;
+  const { category_id: categoryId, new: isNew, page, limit } = req.query;
 
-  const { data, message } = await getBooksInfoService(categoryId, isNew, page, limit);
+  const { data, message } = await getBooksInfoService(+categoryId, isNew, +page, +limit);
   return res.status(StatusCodes.OK).json({ data, message });
 };
 
@@ -15,7 +15,7 @@ const getBookDetail = async (req, res) => {
   const { bookId } = req.params;
   const userId = req.user?.id;
 
-  const { data } = await getBookDetailService(bookId, userId);
+  const { data } = await getBookDetailService(+bookId, userId);
   return res.status(StatusCodes.OK).json({ data });
 };
 

--- a/src/controllers/cartsController.js
+++ b/src/controllers/cartsController.js
@@ -29,7 +29,7 @@ const removeFromCart = async (req, res) => {
   const { id: userId } = req.user;
   const { bookId } = req.params;
 
-  await removeFromCartService(bookId, userId);
+  await removeFromCartService(+bookId, userId);
   return res.status(StatusCodes.NO_CONTENT).json();
 };
 

--- a/src/controllers/likesController.js
+++ b/src/controllers/likesController.js
@@ -12,7 +12,8 @@ const likeAndUnlikeBook = async (req, res) => {
   const { bookId } = req.params;
   const { id: userId } = req.user;
 
-  const { data, message } = await likeAndUnlikeBookService(bookId, userId);
+  const { data, message } = await likeAndUnlikeBookService(+bookId, userId);
+
   if (message === RESPONSE_MESSAGES.LIKED) {
     return res.status(StatusCodes.CREATED).json({ data, message });
   }

--- a/src/controllers/ordersController.js
+++ b/src/controllers/ordersController.js
@@ -35,7 +35,7 @@ const getOrderListDetails = async (req, res) => {
   const { orderId } = req.params;
   const { id: userId } = req.user;
 
-  const { data } = await getOrderListDetailsService(orderId, userId);
+  const { data } = await getOrderListDetailsService(+orderId, userId);
   return res.status(StatusCodes.OK).json({ data });
 };
 

--- a/src/middlewares/authMiddleware.js
+++ b/src/middlewares/authMiddleware.js
@@ -7,7 +7,7 @@ const privateKey = process.env.PRIVATE_KEY;
 
 const authenticateToken = async (req, res, next) => {
   const endPoint = req.originalUrl.slice(0, req.originalUrl.length - 2);
-  const accessToken = req.headers.authorization && req.headers.authorization.split(" ")[1];
+  const accessToken = req.headers.authorization?.split(" ")[1];
   if (!accessToken) {
     if (endPoint === "/api/books") {
       return next();
@@ -49,7 +49,7 @@ const refreshAccessToken = async (req, res, next) => {
 
   const { id: userId } = req.user;
   let sql = "SELECT * FROM users WHERE id=? AND refresh_token=?";
-  let values = [userId, refreshToken];
+  let values = [+userId, refreshToken];
   let [results] = await conn.query(sql, values);
   if (results.length > 0) {
     jwt.verify(refreshToken, privateKey);

--- a/src/middlewares/authMiddleware.js
+++ b/src/middlewares/authMiddleware.js
@@ -3,6 +3,7 @@ const { CustomError, ERROR_MESSAGES } = require("../middlewares/errorHandlerMidd
 const { StatusCodes } = require("http-status-codes");
 const conn = require("../../database/mariadb").promise();
 const jwt = require("jsonwebtoken");
+const { createToken } = require("../utils/createToken");
 const privateKey = process.env.PRIVATE_KEY;
 
 const authenticateToken = async (req, res, next) => {
@@ -55,15 +56,8 @@ const refreshAccessToken = async (req, res, next) => {
     jwt.verify(refreshToken, privateKey);
 
     const targetUser = results[0];
-    let newAccessToken = jwt.sign({ email: targetUser.email, uid: targetUser.id }, privateKey, {
-      expiresIn: process.env.ACCESSTOKEN_LIFETIME,
-      issuer: process.env.ACCESSTOKEN_ISSUER,
-    });
-
-    let newRefreshToken = jwt.sign({ uid: targetUser.id }, privateKey, {
-      expiresIn: process.env.REFRESHTOKEN_LIFETIME,
-      issuer: process.env.REFRESHTOKEN_ISSUER,
-    });
+    const newAccessToken = createToken("accessToken", targetUser);
+    const newRefreshToken = createToken("refreshToken", targetUser);
 
     sql = "UPDATE users SET refresh_token=? WHERE id=?";
     values = [newRefreshToken, targetUser.id];

--- a/src/middlewares/errorHandlerMiddleware.js
+++ b/src/middlewares/errorHandlerMiddleware.js
@@ -10,11 +10,12 @@ const ERROR_MESSAGES = {
   LOGIN_REQUIRED: "로그인이 필요합니다. 로그인 후 이용해주세요.",
   REFRESH_TOKEN_MISMATCH: "refresh token정보가 일치하지 않습니다. 다시 로그인 후 사용해주세요.",
   BOOKS_NOT_FOUND: "존재하지 않는 도서입니다.",
-  ORDER_ERROR: "결제 진행 중 오류가 발생했습니다.",
   DUPLICATE_EMAIL: "이미 가입된 이메일입니다. 다른 이메일을 입력해주세요.",
   LOGIN_UNAUTHORIZED: "로그인 도중에 문제가 생겼습니다. 로그인을 다시 시도해주세요.",
   LOGIN_BAD_REQUEST: "이메일 또는 비밀번호를 잘못 입력했습니다. 입력하신 내용을 다시 확인해주세요.",
   EMAIL_NOT_FOUND: "존재하지 않는 이메일입니다. 가입한 이메일 정보를 정확히 입력해주세요.",
+  ORDER_ERROR: "결제 진행 중 오류가 발생했습니다.",
+  CART_DATA_MISMATCH: "결제 진행 중 오류가 발생했습니다. (장바구니 정보와 일치하지 않습니다.)",
 };
 
 class CustomError extends Error {

--- a/src/middlewares/validateMiddleware.js
+++ b/src/middlewares/validateMiddleware.js
@@ -161,7 +161,7 @@ const validateJoin = [
   validateRequest,
 ];
 const validateLogin = [validateChainEmail, validateChainPassword, validateRequest];
-const validateRequestResetPW = [validateChainPassword, validateRequest];
+const validateRequestResetPW = [validateChainEmail, validateRequest];
 const validateResetPW = [validateChainEmail, validateChainNewPassword, validateRequest];
 const validateGetBooks = [
   validateChainIsInt("query", "page"),

--- a/src/services/booksService.js
+++ b/src/services/booksService.js
@@ -48,7 +48,6 @@ const getBooksInfoService = async (categoryId, isNew, page, limit) => {
   }
 
   const [results] = await conn.query(sql, values);
-  console.log(results);
   if (results.length > 0) {
     const totalBooks = results[0].total_books;
     let books = Object.entries(results)

--- a/src/services/booksService.js
+++ b/src/services/booksService.js
@@ -9,47 +9,46 @@ const RESPONSE_MESSAGES = {
 };
 
 const getBooksInfoService = async (categoryId, isNew, page, limit) => {
-  // 전체 도서 목록 조회
-  limit = parseInt(limit);
-  let offset = (+page - 1) * limit;
-  let sql = `SELECT b.*, c.category_name,
-                (SELECT count(*) FROM likes WHERE likes.liked_book_id=b.id) AS likes,
-                (SELECT count(*) FROM books) AS total_books
-              FROM books AS b INNER JOIN categories AS c USING (category_id)`;
-  let tailSql = " LIMIT ? OFFSET ?";
+  const baseSql = `SELECT b.*, c.category_name,
+                    (SELECT count(*) FROM likes WHERE likes.liked_book_id=b.id) AS likes,
+                    (SELECT count(*) FROM books) AS total_books
+                  FROM books AS b INNER JOIN categories AS c USING (category_id)`;
+  const categorySql = "category_id=?";
+  const isNewBookSql = "published_date BETWEEN DATE_SUB(CURDATE(), INTERVAL 30 DAY) AND CURDATE()";
+  const tailSql = " LIMIT ? OFFSET ?";
+
+  let sql = `${baseSql} ${tailSql}`; // 전체 도서 목록 조회
   let message = RESPONSE_MESSAGES.NO_BOOKS;
+  const offset = (page - 1) * limit;
   let values = [limit, offset];
+  let categoryName = "";
 
   if (categoryId) {
-    let preSql = "SELECT category_name FROM categories WHERE category_id=?";
-    const [results] = await conn.query(preSql, categoryId);
-
-    if (results.length > 0) {
-      let categoryName = results[0].category_name;
-      values = [+categoryId, ...values];
-      if (isNew) {
-        // 카테고리 별 신간 도서 목록 조회(출판일이 현재 일자 기준으로 30일 이내인 도서)
-        sql = `${sql} WHERE category_id=? AND published_date BETWEEN DATE_SUB(CURDATE(), INTERVAL 30 DAY) AND CURDATE()`;
-        message =
-          page > 1
-            ? ERROR_MESSAGES.BAD_REQUEST
-            : `${categoryName} 카테고리에는 ${RESPONSE_MESSAGES.NO_RECENTLY_PUBLISHED_BOOKS}`;
-      } else {
-        // 카테고리 별 도서 목록 조회
-        sql = `${sql} WHERE category_id=?`;
-        message =
-          page > 1
-            ? ERROR_MESSAGES.BAD_REQUEST
-            : `${categoryName} 카테고리에는 ${RESPONSE_MESSAGES.NO_BOOKS}`;
-      }
+    const preSql = `SELECT * FROM categories WHERE category_id=?`;
+    const [preResults] = await conn.query(preSql, [categoryId]);
+    if (preResults.length === 0) {
+      throw new CustomError(ERROR_MESSAGES.BAD_REQUEST, StatusCodes.BAD_REQUEST);
     }
-  } else if (!categoryId && isNew) {
-    // 신간 도서 목록 조회 (전체 카테고리 통합)
-    sql = `${sql} WHERE published_date BETWEEN DATE_SUB(CURDATE(), INTERVAL 30 DAY) AND CURDATE()`;
-    message = page > 1 ? ERROR_MESSAGES.BAD_REQUEST : RESPONSE_MESSAGES.NO_RECENTLY_PUBLISHED_BOOKS;
+    categoryName = preResults[0].category_name;
+    values = [categoryId, ...values];
   }
 
-  const [results] = await conn.query(sql + tailSql, values);
+  if (categoryId && isNew) {
+    // 카테고리 별 신간 도서 목록 조회 (출판일이 현재 일자 기준으로 30일 이내인 도서)
+    sql = `${baseSql} WHERE ${categorySql} AND ${isNewBookSql} ${tailSql}`;
+    message = `${categoryName} 카테고리에는 ${RESPONSE_MESSAGES.NO_RECENTLY_PUBLISHED_BOOKS}`;
+  } else if (categoryId && !isNew) {
+    // 카테고리 별 도서 목록 조회
+    sql = `${baseSql} WHERE ${categorySql} ${tailSql}`;
+    message = `${categoryName} 카테고리에는 ${RESPONSE_MESSAGES.NO_BOOKS}`;
+  } else if (!categoryId && isNew) {
+    // 신간 도서 목록 조회 (전체 카테고리 통합)
+    sql = `${baseSql} WHERE ${isNewBookSql} ${tailSql}`;
+    message = RESPONSE_MESSAGES.NO_RECENTLY_PUBLISHED_BOOKS;
+  }
+
+  const [results] = await conn.query(sql, values);
+  console.log(results);
   if (results.length > 0) {
     const totalBooks = results[0].total_books;
     let books = Object.entries(results)
@@ -59,19 +58,21 @@ const getBooksInfoService = async (categoryId, isNew, page, limit) => {
     return { data: { books, pagination: { totalBooks, page } }, message: null };
   }
 
-  if (message === ERROR_MESSAGES.BAD_REQUEST) {
-    throw new CustomError(message, StatusCodes.BAD_REQUEST);
+  if (page > 1) {
+    // 조회 가능한 페이지 번호가 아닌 경우
+    throw new CustomError(ERROR_MESSAGES.BAD_REQUEST, StatusCodes.BAD_REQUEST);
   }
+
   return { data: {}, message };
 };
 
 const getBookDetailService = async (bookId, userId) => {
   // 로그인 하지 않은 유저가 개별 도서 조회 api를 호출한 경우
   let sql = `SELECT b.*, c.category_name,
-        (SELECT COUNT(*) FROM likes WHERE liked_book_id = b.id) AS likes
-      FROM books AS b INNER JOIN categories AS c USING (category_id) 
-      WHERE b.id = ?`;
-  let values = [+bookId];
+              (SELECT COUNT(*) FROM likes WHERE liked_book_id = b.id) AS likes
+            FROM books AS b INNER JOIN categories AS c USING (category_id) 
+            WHERE b.id = ?`;
+  let values = [bookId];
 
   if (userId) {
     // 로그인한 유저가 개별 도서 조회 api를 호출한 경우(accessToken 유효성 검증 과정이 선행됨)
@@ -81,7 +82,7 @@ const getBookDetailService = async (bookId, userId) => {
         EXISTS (SELECT 1 FROM likes WHERE user_id = ? AND liked_book_id = ?) AS is_liked 
       FROM books AS b INNER JOIN categories AS c USING (category_id) 
       WHERE b.id = ?`;
-    values = [+userId, +bookId, +bookId];
+    values = [+userId, bookId, bookId];
   }
 
   const [results] = await conn.query(sql, values);

--- a/src/services/cartsService.js
+++ b/src/services/cartsService.js
@@ -10,38 +10,41 @@ const RESPONSE_MESSAGES = {
 
 const addTocartService = async (bookId, quantity, userId) => {
   let sql = "SELECT * FROM books WHERE id=?";
-  let [results] = await conn.query(sql, [+bookId]);
+  let [results] = await conn.query(sql, [bookId]);
   if (results.length > 0) {
     // 동일한 물품이 장바구니에 존재하는지 확인
     sql = "SELECT * FROM cart_items WHERE user_id=? AND book_id=?";
-    let values = [+userId, +bookId];
+    let values = [userId, bookId];
+    let setQuantity = quantity;
     [results] = await conn.query(sql, values);
+
     if (results.length > 0) {
       // 동일한 물품이 있다면 수량만 수정함
-      quantity = parseInt(quantity) + results[0].quantity;
+      setQuantity += results[0].quantity;
       sql = "UPDATE cart_items SET quantity=? WHERE user_id=? AND book_id=?";
     } else {
       // 없다면 데이터 그대로 삽입
       sql = "INSERT INTO cart_items (quantity, user_id, book_id) VALUES(?, ?, ?)";
     }
 
-    values = [+quantity, +userId, +bookId];
+    values = [setQuantity, userId, bookId];
     [results] = await conn.query(sql, values);
     if (results.affectedRows > 0) {
       return { message: RESPONSE_MESSAGES.ADD_TO_CART };
     }
     throw new CustomError(ERROR_MESSAGES.BAD_REQUEST, StatusCodes.BAD_REQUEST);
   }
+
   throw new CustomError(ERROR_MESSAGES.BOOKS_NOT_FOUND, StatusCodes.NOT_FOUND);
 };
 
 const getCartItemsService = async (cartItemIds, userId) => {
   // 장바구니 전체 목록 조회
-  let sql = `SELECT c.id AS cart_item_id, c.book_id, b.title, b.summary, b.price, c.quantity 
+  const sql = `SELECT c.id AS cart_item_id, c.book_id, b.title, b.summary, b.price, c.quantity 
               FROM cart_items AS c INNER JOIN books AS b ON c.book_id = b.id 
               WHERE c.user_id=?`;
   const tailSql = " AND c.id IN (?)";
-  let values = [+userId];
+  let values = [userId];
 
   if (cartItemIds) {
     // 장바구니에서 선택한 물품 목록(주문 예상 물품 목록) 조회

--- a/src/services/likesService.js
+++ b/src/services/likesService.js
@@ -8,33 +8,30 @@ const RESPONSE_MESSAGES = {
 };
 
 const likeAndUnlikeBookService = async (bookId, userId) => {
-  let sql = "SELECT * FROM likes WHERE user_id=? AND liked_book_id=?";
-  let values = [+userId, +bookId];
-  let [results] = await conn.query(sql, values);
+  const checkLikeSql = "SELECT * FROM likes WHERE user_id=? AND liked_book_id=?";
+  const unLikeSql = "DELETE FROM likes WHERE user_id=? AND liked_book_id=?";
+  const addLikeSql = "INSERT INTO likes(user_id, liked_book_id) VALUES(?, ?)";
+  const countLikesSql = "SELECT COUNT(*) AS likes FROM likes WHERE liked_book_id = ?";
+
+  let [results] = await conn.query(checkLikeSql, [userId, bookId]);
+
   if (results.length > 0) {
     // 이미 사용자가 해당 도서를 "좋아요" 해둔 경우 -> 좋아요 취소 진행(toggle)
-    sql = "DELETE FROM likes WHERE user_id=? AND liked_book_id=?";
-    values = [+userId, +bookId];
-    [results] = await conn.query(sql, values);
+    [results] = await conn.query(unLikeSql, [userId, bookId]);
     if (results.affectedRows === 1) {
-      sql = `SELECT COUNT(*) AS likes FROM likes WHERE liked_book_id = ?`;
-      const [getLikesResults] = await conn.query(sql, +bookId);
-      let likes = getLikesResults[0].likes;
+      [results] = await conn.query(countLikesSql, bookId);
+      const likes = results[0].likes;
       return { data: { likes }, message: RESPONSE_MESSAGES.UNLIKED };
     }
   } else {
     // 사용자가 해당 도서를 "좋아요" 해두지 않은 경우 -> 좋아요 추가
-    sql = "INSERT INTO likes(user_id, liked_book_id) VALUES(?,  ?);";
-    values = [+userId, +bookId];
-    [results] = await conn.query(sql, values);
+    [results] = await conn.query(addLikeSql, [userId, bookId]);
     if (results.affectedRows === 1) {
-      sql = `SELECT COUNT(*) AS likes FROM likes WHERE liked_book_id = ?`;
-      const [getLikesResults] = await conn.query(sql, +bookId);
-      let likes = getLikesResults[0].likes;
+      [results] = await conn.query(countLikesSql, bookId);
+      const likes = results[0].likes;
       return { data: { likes }, message: RESPONSE_MESSAGES.LIKED };
     }
   }
-
   throw new CustomError(ERROR_MESSAGES.BAD_REQUEST, StatusCodes.BAD_REQUEST);
 };
 

--- a/src/services/usersService.js
+++ b/src/services/usersService.js
@@ -2,7 +2,7 @@ const conn = require("../../database/mariadb").promise();
 const { StatusCodes } = require("http-status-codes");
 const { CustomError, ERROR_MESSAGES } = require("../middlewares/errorHandlerMiddleware");
 const jwt = require("jsonwebtoken");
-const crypto = require("crypto");
+const { encryptPassword } = require("../utils/encryptPassword");
 require("dotenv").config();
 const privateKey = process.env.PRIVATE_KEY;
 
@@ -21,8 +21,7 @@ const joinService = async (email, password, name, contact) => {
   }
 
   // 비밀번호 암호화
-  const salt = crypto.randomBytes(32).toString("base64");
-  const hashPassword = crypto.pbkdf2Sync(password, salt, 10000, 32, "sha512").toString("base64");
+  const { hashPassword, salt } = encryptPassword(password);
 
   sql = "INSERT INTO users (email, password, name, contact, salt) VALUES (?, ?, ?, ?, ?)";
   const values = [email, hashPassword, name, contact, salt];
@@ -41,8 +40,7 @@ const loginService = async (email, password) => {
   if (results.length === 1) {
     const targetUser = results[0];
     // db에 저장된 salt값으로 입력받은 비밀번호를 암호화
-    const salt = targetUser.salt;
-    const hashPassword = crypto.pbkdf2Sync(password, salt, 10000, 32, "sha512").toString("base64");
+    const { hashPassword } = encryptPassword(password, targetUser.salt);
 
     // db에 저장되어 있는 암호화된 비밀번호와 일치하는지 확인
     if (targetUser.password === hashPassword) {
@@ -103,8 +101,7 @@ const requestPwdResetService = async (email) => {
 
 /* 비밀번호 초기화(새로운 비밀번호로 변경하는 기능) */
 const performPwdResetService = async (email, newPW) => {
-  const salt = crypto.randomBytes(32).toString("base64");
-  const hashPassword = crypto.pbkdf2Sync(newPW, salt, 10000, 32, "sha512").toString("base64");
+  const { hashPassword, salt } = encryptPassword(newPW);
 
   const sql = "UPDATE users SET password=?, salt=? WHERE email=?";
   const values = [hashPassword, salt, email];

--- a/src/utils/createToken.js
+++ b/src/utils/createToken.js
@@ -1,0 +1,25 @@
+const jwt = require("jsonwebtoken");
+require("dotenv").config();
+const privateKey = process.env.PRIVATE_KEY;
+
+const createToken = (type, user) => {
+  const { email, id: uid } = user;
+  const tokenData = {
+    accessToken: { email, uid },
+    refreshToken: { uid },
+  };
+  const tokenConfig = {
+    accessTokenConfig: {
+      expiresIn: process.env.ACCESSTOKEN_LIFETIME,
+      issuer: process.env.ACCESSTOKEN_ISSUER,
+    },
+    refreshTokenConfig: {
+      expiresIn: process.env.REFRESHTOKEN_LIFETIME,
+      issuer: process.env.REFRESHTOKEN_ISSUER,
+    },
+  };
+
+  const token = jwt.sign(tokenData[type], privateKey, tokenConfig[type]);
+  return token;
+};
+module.exports = { createToken };

--- a/src/utils/encryptPassword.js
+++ b/src/utils/encryptPassword.js
@@ -1,0 +1,11 @@
+const crypto = require("crypto");
+
+const encryptPassword = (password, oldSalt = null) => {
+  // 비밀번호 암호화
+  const salt = oldSalt ? oldSalt : crypto.randomBytes(32).toString("base64");
+  const hashPassword = crypto.pbkdf2Sync(password, salt, 10000, 32, "sha512").toString("base64");
+
+  return { hashPassword, salt };
+};
+
+module.exports = { encryptPassword };


### PR DESCRIPTION
## 변경 사항
- 모든 API의 모든 API의 Controller와 Service코드를 리팩토링
  - 도서 조회 api에서 if문의 depth가 3인 코드를 depth 2로 수정  
  - 주문 요청 api에서 장바구니에 담긴 도서 정보와 일치하는지 판단하는 로직을 따로 분리하여 함수로 생성 
  - 모든 Controller 파일에서 전달되는 파라미터의 데이터 타입을 무분별하게 단항 연산자로 타입 캐스팅 시킨 것을 제거하고 String타입으로 전달되는 숫자 인자에만 Number타입으로 변경시킴(request 객체의 params, query로 받아서 전달하는 값들)
- 유효성 검사 미들웨어에서, 비밀번호 초기화 요청에 관련된 유효성 검사 로직 수정

## 중복코드 제거 및 재사용성 증가를 위한 개선  
- 비밀번호 암호화 하는 로직을 유틸 함수로 분리
- JWT 토큰을 생성하는 로직을 유틸 함수로 분리