### PR TITLE
[refactor]: 리팩토링/[fix]: 버그 해결/[feat]: 새로운 기능 추가

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,6 +8,7 @@ const app = express();
 const port = process.env.PORT;
 
 const usersRouter = require("./src/routes/users");
+const aladinBooksRouter = require("./src/routes/aladinBooks");
 const booksRouter = require("./src/routes/books");
 const cartsRouter = require("./src/routes/carts");
 const likesRouter = require("./src/routes/likes");
@@ -26,6 +27,7 @@ app.use(express.json());
 app.use(morgan("dev"));
 app.use(cookieParser());
 
+app.use("/api/aladin", aladinBooksRouter);
 app.use("/api/users", usersRouter);
 app.use("/api/books", booksRouter);
 app.use("/api/carts", cartsRouter);

--- a/app.js
+++ b/app.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const morgan = require("morgan");
 const cookieParser = require("cookie-parser");
+const cors = require("cors");
 require("dotenv").config();
 
 const app = express();
@@ -13,6 +14,13 @@ const likesRouter = require("./src/routes/likes");
 const ordersRouter = require("./src/routes/orders");
 const categoriesRouter = require("./src/routes/categories");
 const { errorHandler, handleNotFound } = require("./src/middlewares/errorHandlerMiddleware");
+
+const corsOptions = {
+  origin: process.env.ORIGIN,
+  credentials: true,
+  exposedHeaders: ["Authorization"],
+};
+app.use(cors(corsOptions));
 
 app.use(express.json());
 app.use(morgan("dev"));

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "axios": "^1.6.8",
         "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
@@ -54,6 +55,21 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -179,6 +195,17 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -267,6 +294,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/denque": {
@@ -418,6 +453,38 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/forwarded": {
@@ -1032,6 +1099,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "cookie-parser": "^1.4.6",
+        "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "express-validator": "^7.0.1",
@@ -234,6 +235,18 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -945,6 +958,14 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "axios": "^1.6.8",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "cookie-parser": "^1.4.6",
+    "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "express-validator": "^7.0.1",

--- a/src/api/aladinHttp.js
+++ b/src/api/aladinHttp.js
@@ -2,6 +2,7 @@ const axios = require("axios");
 
 const ALADIN_LIST_BASE_URL = process.env.ALADIN_BOOK_LIST_BASE_URL;
 const ALADIN_ITEM_BASE_URL = process.env.ALADIN_BOOK_ITEM_BASE_URL;
+const ALADIN_SEARCH_BOOKS_BASE_URL = process.env.ALADIN_SEARCH_BOOKS_BASE_URL;
 const ALADIN_KEY = process.env.ALADIN_KEY;
 
 const createAxiosInstance = (baseURL) => {
@@ -16,8 +17,10 @@ const createAxiosInstance = (baseURL) => {
 
 const aladinBookListAxios = createAxiosInstance(ALADIN_LIST_BASE_URL);
 const aladinBookItemAxios = createAxiosInstance(ALADIN_ITEM_BASE_URL);
+const aladinSearchBooksAxios = createAxiosInstance(ALADIN_SEARCH_BOOKS_BASE_URL);
 
 module.exports = {
   aladinBookListAxios,
   aladinBookItemAxios,
+  aladinSearchBooksAxios,
 };

--- a/src/api/aladinHttp.js
+++ b/src/api/aladinHttp.js
@@ -1,0 +1,23 @@
+const axios = require("axios");
+
+const ALADIN_LIST_BASE_URL = process.env.ALADIN_BOOK_LIST_BASE_URL;
+const ALADIN_ITEM_BASE_URL = process.env.ALADIN_BOOK_ITEM_BASE_URL;
+const ALADIN_KEY = process.env.ALADIN_KEY;
+
+const createAxiosInstance = (baseURL) => {
+  return axios.create({
+    baseURL: baseURL,
+    params: {
+      ttbkey: ALADIN_KEY,
+    },
+    withCredentials: true,
+  });
+};
+
+const aladinBookListAxios = createAxiosInstance(ALADIN_LIST_BASE_URL);
+const aladinBookItemAxios = createAxiosInstance(ALADIN_ITEM_BASE_URL);
+
+module.exports = {
+  aladinBookListAxios,
+  aladinBookItemAxios,
+};

--- a/src/controllers/aladinBooksController.js
+++ b/src/controllers/aladinBooksController.js
@@ -2,6 +2,7 @@ const { StatusCodes } = require("http-status-codes");
 const { asyncWrapper } = require("../middlewares/asyncWrapperMiddleware");
 const querystring = require("querystring");
 const { aladinBookListAxios, aladinBookItemAxios } = require("../api/aladinHttp");
+const { likesCountService, isLikedService } = require("../services/likesService");
 
 /* 도서 목록 조회 */
 const getAladinBookList = async (req, res) => {
@@ -15,12 +16,19 @@ const getAladinBookList = async (req, res) => {
 
 /* 개별 도서 조회 */
 const getAladinBookItem = async (req, res) => {
+  const userId = req.user?.id;
   const queryString = querystring.stringify(req.query);
   const url = `${process.env.ALADIN_BASE_URL}?${queryString}`;
   const response = await aladinBookItemAxios.get(url);
-  const { item } = response.data;
 
-  return res.status(StatusCodes.OK).json(item);
+  const params = new URLSearchParams(queryString);
+  const bookId = params.get("ItemId");
+  const { likes } = await likesCountService(bookId);
+  const { isLiked } = await isLikedService(bookId, userId);
+
+  const { item } = response.data;
+  const data = { ...item, likes, isLiked };
+  return res.status(StatusCodes.OK).json(data);
 };
 
 module.exports = {

--- a/src/controllers/aladinBooksController.js
+++ b/src/controllers/aladinBooksController.js
@@ -1,0 +1,29 @@
+const { StatusCodes } = require("http-status-codes");
+const { asyncWrapper } = require("../middlewares/asyncWrapperMiddleware");
+const querystring = require("querystring");
+const { aladinBookListAxios, aladinBookItemAxios } = require("../api/aladinHttp");
+
+/* 도서 목록 조회 */
+const getAladinBookList = async (req, res) => {
+  const queryString = querystring.stringify(req.query);
+  const url = `${process.env.ALADIN_BASE_URL}?${queryString}`;
+  const response = await aladinBookListAxios.get(url);
+  const { item } = response.data;
+
+  return res.status(StatusCodes.OK).json(item);
+};
+
+/* 개별 도서 조회 */
+const getAladinBookItem = async (req, res) => {
+  const queryString = querystring.stringify(req.query);
+  const url = `${process.env.ALADIN_BASE_URL}?${queryString}`;
+  const response = await aladinBookItemAxios.get(url);
+  const { item } = response.data;
+
+  return res.status(StatusCodes.OK).json(item);
+};
+
+module.exports = {
+  getAladinBookList: asyncWrapper(getAladinBookList),
+  getAladinBookItem: asyncWrapper(getAladinBookItem),
+};

--- a/src/controllers/aladinBooksController.js
+++ b/src/controllers/aladinBooksController.js
@@ -1,14 +1,17 @@
 const { StatusCodes } = require("http-status-codes");
 const { asyncWrapper } = require("../middlewares/asyncWrapperMiddleware");
 const querystring = require("querystring");
-const { aladinBookListAxios, aladinBookItemAxios } = require("../api/aladinHttp");
+const {
+  aladinBookListAxios,
+  aladinBookItemAxios,
+  aladinSearchBooksAxios,
+} = require("../api/aladinHttp");
 const { likesCountService, isLikedService } = require("../services/likesService");
 
 /* 도서 목록 조회 */
 const getAladinBookList = async (req, res) => {
   const queryString = querystring.stringify(req.query);
-  const url = `${process.env.ALADIN_BASE_URL}?${queryString}`;
-  const response = await aladinBookListAxios.get(url);
+  const response = await aladinBookListAxios.get(`?${queryString}`);
   const { item } = response.data;
 
   return res.status(StatusCodes.OK).json(item);
@@ -18,8 +21,7 @@ const getAladinBookList = async (req, res) => {
 const getAladinBookItem = async (req, res) => {
   const userId = req.user?.id;
   const queryString = querystring.stringify(req.query);
-  const url = `${process.env.ALADIN_BASE_URL}?${queryString}`;
-  const response = await aladinBookItemAxios.get(url);
+  const response = await aladinBookItemAxios.get(`?${queryString}`);
 
   const params = new URLSearchParams(queryString);
   const bookId = params.get("ItemId");
@@ -31,7 +33,17 @@ const getAladinBookItem = async (req, res) => {
   return res.status(StatusCodes.OK).json(data);
 };
 
+/* 도서 검색 조회 */
+const getSearchAladinBooks = async (req, res) => {
+  const queryString = querystring.stringify(req.query);
+  const response = await aladinSearchBooksAxios.get(`?${queryString}`);
+
+  const { totalResults, startIndex, item } = response.data;
+  return res.status(StatusCodes.OK).json({ item, totalResults, startIndex });
+};
+
 module.exports = {
   getAladinBookList: asyncWrapper(getAladinBookList),
   getAladinBookItem: asyncWrapper(getAladinBookItem),
+  getSearchAladinBooks: asyncWrapper(getSearchAladinBooks),
 };

--- a/src/controllers/booksController.js
+++ b/src/controllers/booksController.js
@@ -7,7 +7,7 @@ const getBooksInfo = async (req, res) => {
   const { category_id: categoryId, new: isNew, page, limit } = req.query;
 
   const { data, message } = await getBooksInfoService(+categoryId, isNew, +page, +limit);
-  return res.status(StatusCodes.OK).json({ data, message });
+  return res.status(StatusCodes.OK).json({ ...data, message });
 };
 
 /* 개별 도서 조회 */
@@ -16,7 +16,7 @@ const getBookDetail = async (req, res) => {
   const userId = req.user?.id;
 
   const { data } = await getBookDetailService(+bookId, userId);
-  return res.status(StatusCodes.OK).json({ data });
+  return res.status(StatusCodes.OK).json({ ...data });
 };
 
 module.exports = {

--- a/src/controllers/cartsController.js
+++ b/src/controllers/cartsController.js
@@ -9,10 +9,10 @@ const {
 
 /* 장바구니에 담기 */
 const addTocart = async (req, res) => {
-  let { bookId, quantity } = req.body;
+  let { bookId, quantity, info } = req.body;
   const { id: userId } = req.user;
 
-  const { data, message } = await addTocartService(bookId, quantity, userId);
+  const { data, message } = await addTocartService(bookId, quantity, userId, info);
   return res.status(StatusCodes.CREATED).json({ ...data, message });
 };
 

--- a/src/controllers/cartsController.js
+++ b/src/controllers/cartsController.js
@@ -21,15 +21,15 @@ const getCartItems = async (req, res) => {
   const { id: userId } = req.user;
 
   const { data, message } = await getCartItemsService(cartItemIds, userId);
-  return res.status(StatusCodes.OK).json({ data, message });
+  return res.status(StatusCodes.OK).json({ ...data, message });
 };
 
 /* 장바구니에서 물품 제거 */
 const removeFromCart = async (req, res) => {
   const { id: userId } = req.user;
-  const { bookId } = req.params;
+  const { cartItemId } = req.params;
 
-  await removeFromCartService(+bookId, userId);
+  await removeFromCartService(+cartItemId, userId);
   return res.status(StatusCodes.NO_CONTENT).json();
 };
 

--- a/src/controllers/cartsController.js
+++ b/src/controllers/cartsController.js
@@ -4,6 +4,7 @@ const {
   addTocartService,
   getCartItemsService,
   removeFromCartService,
+  changeQuantityCartItemService,
 } = require("../services/cartsService");
 
 /* 장바구니에 담기 */
@@ -33,8 +34,19 @@ const removeFromCart = async (req, res) => {
   return res.status(StatusCodes.NO_CONTENT).json();
 };
 
+/* 장바구니 물품 수량 변경*/
+const changeQuantityCartItem = async (req, res) => {
+  const { id: userId } = req.user;
+  const { quantity } = req.body;
+  const { cartItemId } = req.params;
+
+  const { message } = await changeQuantityCartItemService(+cartItemId, quantity, userId);
+  return res.status(StatusCodes.OK).json({ message });
+};
+
 module.exports = {
   addTocart: asyncWrapper(addTocart),
   getCartItems: asyncWrapper(getCartItems),
   removeFromCart: asyncWrapper(removeFromCart),
+  changeQuantityCartItem: asyncWrapper(changeQuantityCartItem),
 };

--- a/src/controllers/cartsController.js
+++ b/src/controllers/cartsController.js
@@ -11,8 +11,8 @@ const addTocart = async (req, res) => {
   let { bookId, quantity } = req.body;
   const { id: userId } = req.user;
 
-  const { message } = await addTocartService(bookId, quantity, userId);
-  return res.status(StatusCodes.CREATED).json({ message });
+  const { data, message } = await addTocartService(bookId, quantity, userId);
+  return res.status(StatusCodes.CREATED).json({ ...data, message });
 };
 
 /* 장바구니 목록 조회 */

--- a/src/controllers/categoriesController.js
+++ b/src/controllers/categoriesController.js
@@ -5,7 +5,7 @@ const { getAllCategoriesService } = require("../services/categoriesService");
 /* 카테고리 전체 목록 조회 */
 const getAllCategories = async (req, res) => {
   const { data, message } = await getAllCategoriesService();
-  return res.status(StatusCodes.OK).json({ data, message });
+  return res.status(StatusCodes.OK).json({ ...data, message });
 };
 
 module.exports = { getAllCategories: asyncWrapper(getAllCategories) };

--- a/src/controllers/likesController.js
+++ b/src/controllers/likesController.js
@@ -17,7 +17,7 @@ const likeAndUnlikeBook = async (req, res) => {
   if (message === RESPONSE_MESSAGES.LIKED) {
     return res.status(StatusCodes.CREATED).json({ data, message });
   }
-  return res.status(StatusCodes.OK).json({ data, message });
+  return res.status(StatusCodes.OK).json({ ...data, message });
 };
 
 module.exports = { likeAndUnlikeBook: asyncWrapper(likeAndUnlikeBook) };

--- a/src/controllers/likesController.js
+++ b/src/controllers/likesController.js
@@ -1,6 +1,6 @@
 const { StatusCodes } = require("http-status-codes");
 const { asyncWrapper } = require("../middlewares/asyncWrapperMiddleware");
-const { likeAndUnlikeBookService } = require("../services/likesService");
+const { likeAndUnlikeBookService, insertBookInfoService } = require("../services/likesService");
 
 const RESPONSE_MESSAGES = {
   LIKED: "좋아요 추가!",
@@ -11,7 +11,9 @@ const RESPONSE_MESSAGES = {
 const likeAndUnlikeBook = async (req, res) => {
   const { bookId } = req.params;
   const { id: userId } = req.user;
+  const info = req.body;
 
+  await insertBookInfoService(+bookId, info);
   const { data, message } = await likeAndUnlikeBookService(+bookId, userId);
 
   if (message === RESPONSE_MESSAGES.LIKED) {

--- a/src/controllers/ordersController.js
+++ b/src/controllers/ordersController.js
@@ -27,7 +27,7 @@ const getOrderList = async (req, res) => {
   const { id: userId } = req.user;
 
   const { data, message } = await getOrderListService(userId);
-  return res.status(StatusCodes.OK).json({ data, message });
+  return res.status(StatusCodes.OK).json({ ...data, message });
 };
 
 /* 주문 내역의 상품 상세 조회 */
@@ -36,7 +36,7 @@ const getOrderListDetails = async (req, res) => {
   const { id: userId } = req.user;
 
   const { data } = await getOrderListDetailsService(+orderId, userId);
-  return res.status(StatusCodes.OK).json({ data });
+  return res.status(StatusCodes.OK).json({ ...data });
 };
 
 module.exports = {

--- a/src/controllers/usersController.js
+++ b/src/controllers/usersController.js
@@ -33,7 +33,7 @@ const login = async (req, res) => {
 
   res.header("Authorization", `Bearer ${accessToken}`);
 
-  return res.status(StatusCodes.OK).json({ data });
+  return res.status(StatusCodes.OK).json({ ...data });
 };
 
 /* 로그아웃 */
@@ -57,7 +57,7 @@ const requestPwdReset = async (req, res) => {
   const { email } = req.body;
 
   const { data } = await requestPwdResetService(email);
-  return res.status(StatusCodes.OK).json({ data });
+  return res.status(StatusCodes.OK).json({ ...data });
 };
 
 /* 비밀번호 초기화(새로운 비밀번호로 변경하는 기능) */

--- a/src/middlewares/authMiddleware.js
+++ b/src/middlewares/authMiddleware.js
@@ -46,20 +46,34 @@ const refreshAccessToken = async (req, res, next) => {
     throw new CustomError(ERROR_MESSAGES.TOKEN_EXPIRED);
   }
 
-  const { id: userId } = req.user;
-  const { newAccessToken, newRefreshToken } = await refreshAccessTokenService(userId, refreshToken);
+  try {
+    const { id: userId } = req.user;
+    const { newAccessToken, newRefreshToken } = await refreshAccessTokenService(
+      userId,
+      refreshToken,
+    );
 
-  res.cookie("refresh_token", newRefreshToken, {
-    httpOnly: true,
-    secure: true,
-    sameSite: "strict",
-    path: "/",
-    maxAge: 1000 * 60 * 60 * 24 * 14, // 14일
-  });
+    res.cookie("refresh_token", newRefreshToken, {
+      httpOnly: true,
+      secure: true,
+      sameSite: "strict",
+      path: "/",
+      maxAge: 1000 * 60 * 60 * 24 * 14, // 14일
+    });
 
-  res.header("Authorization", `Bearer ${newAccessToken}`);
-  console.log("Access token refreshed.");
-  return next();
+    res.header("Authorization", `Bearer ${newAccessToken}`);
+    console.log("Access token refreshed.");
+    return next();
+  } catch (err) {
+    res.cookie("refresh_token", "", {
+      httpOnly: true,
+      secure: true,
+      sameSite: "Strict",
+      path: "/",
+      maxAge: 0,
+    });
+    return next(err);
+  }
 };
 
 module.exports = {

--- a/src/middlewares/authMiddleware.js
+++ b/src/middlewares/authMiddleware.js
@@ -1,6 +1,5 @@
 const { asyncWrapper } = require("../middlewares/asyncWrapperMiddleware");
 const { CustomError, ERROR_MESSAGES } = require("../middlewares/errorHandlerMiddleware");
-const { StatusCodes } = require("http-status-codes");
 const { refreshAccessTokenService } = require("../services/authService");
 const jwt = require("jsonwebtoken");
 const privateKey = process.env.PRIVATE_KEY;
@@ -12,7 +11,7 @@ const authenticateToken = async (req, res, next) => {
     if (endPoint === "/api/books") {
       return next();
     } else {
-      throw new CustomError(ERROR_MESSAGES.LOGIN_REQUIRED, StatusCodes.UNAUTHORIZED);
+      throw new CustomError(ERROR_MESSAGES.LOGIN_REQUIRED);
     }
   }
 
@@ -44,7 +43,7 @@ const refreshAccessToken = async (req, res, next) => {
 
   const { refresh_token: refreshToken } = req.cookies;
   if (!refreshToken) {
-    throw new CustomError(ERROR_MESSAGES.TOKEN_EXPIRED, StatusCodes.UNAUTHORIZED);
+    throw new CustomError(ERROR_MESSAGES.TOKEN_EXPIRED);
   }
 
   const { id: userId } = req.user;

--- a/src/middlewares/authMiddleware.js
+++ b/src/middlewares/authMiddleware.js
@@ -5,7 +5,7 @@ const jwt = require("jsonwebtoken");
 const privateKey = process.env.PRIVATE_KEY;
 
 const authenticateToken = async (req, res, next) => {
-  const endPoint = req.originalUrl.slice(0, req.originalUrl.length - 2);
+  const endPoint = req.originalUrl.split("/").slice(0, 3).join("/");
   const accessToken = req.headers.authorization?.split(" ")[1];
   if (!accessToken) {
     if (endPoint === "/api/books") {

--- a/src/middlewares/authMiddleware.js
+++ b/src/middlewares/authMiddleware.js
@@ -2,13 +2,13 @@ const { asyncWrapper } = require("../middlewares/asyncWrapperMiddleware");
 const { CustomError, ERROR_MESSAGES } = require("../middlewares/errorHandlerMiddleware");
 const { refreshAccessTokenService } = require("../services/authService");
 const jwt = require("jsonwebtoken");
-const privateKey = process.env.PRIVATE_KEY;
 
 const authenticateToken = async (req, res, next) => {
-  const endPoint = req.originalUrl.split("/").slice(0, 3).join("/");
+  const privateKey = process.env.PRIVATE_KEY;
   const accessToken = req.headers.authorization?.split(" ")[1];
   if (!accessToken) {
-    if (endPoint === "/api/books") {
+    const endPoint = req.originalUrl.split("?")[0];
+    if (endPoint === "/api/aladin/item") {
       return next();
     } else {
       throw new CustomError(ERROR_MESSAGES.LOGIN_REQUIRED);

--- a/src/middlewares/errorHandlerMiddleware.js
+++ b/src/middlewares/errorHandlerMiddleware.js
@@ -8,7 +8,7 @@ const ERROR_MESSAGES = {
   TOKEN_EXPIRED: "로그인(인증) 토큰이 만료되었습니다. 다시 로그인 후 사용해주세요.",
   INVALID_TOKEN: "유효하지 않은 토큰입니다.",
   LOGIN_REQUIRED: "로그인이 필요합니다. 로그인 후 이용해주세요.",
-  REFRESH_TOKEN_MISMATCH: "refresh token정보가 일치하지 않습니다. 다시 로그인 후 사용해주세요.",
+  REFRESH_TOKEN_MISMATCH: "문제가 발생했습니다. 다시 로그인 후 사용해주세요.",
   REFRESH_TOKEN_RESET_FAILED: "Refresh Token 초기화에 실패했습니다. 다시 로그인 후 사용해주세요.",
   BOOKS_NOT_FOUND: "존재하지 않는 도서입니다.",
   DUPLICATE_EMAIL: "이미 가입된 이메일입니다. 다른 이메일을 입력해주세요.",

--- a/src/middlewares/errorHandlerMiddleware.js
+++ b/src/middlewares/errorHandlerMiddleware.js
@@ -14,27 +14,28 @@ const ERROR_MESSAGES = {
   DUPLICATE_EMAIL: "이미 가입된 이메일입니다. 다른 이메일을 입력해주세요.",
   LOGIN_UNAUTHORIZED: "로그인 도중에 문제가 생겼습니다. 로그인을 다시 시도해주세요.",
   LOGIN_BAD_REQUEST: "이메일 또는 비밀번호를 잘못 입력했습니다. 입력하신 내용을 다시 확인해주세요.",
-  EMAIL_NOT_FOUND: "존재하지 않는 이메일입니다. 가입한 이메일 정보를 정확히 입력해주세요.",
+  EMAIL_NOT_FOUND: "존재하지 않는 이메일입니다. 가입한 이메일을 정확히 입력해주세요.",
   ORDER_ERROR: "결제 진행 중 오류가 발생했습니다.",
   CART_DATA_MISMATCH: "결제 진행 중 오류가 발생했습니다. (장바구니 정보와 일치하지 않습니다.)",
 };
 
 class CustomError extends Error {
-  constructor(errorMessages, statusCode, multiErrMsg = false) {
-    const message = Array.isArray(errorMessages) ? errorMessages.join(", ") : String(errorMessages);
+  constructor(errorMessages, statusCode, isObject = false) {
+    // const message = Array.isArray(errorMessages) ? errorMessages.join(", ") : String(errorMessages);
 
-    super(message || getReasonPhrase(statusCode));
+    super();
     this.name = "CustomError";
     this.statusCode = statusCode || StatusCodes.INTERNAL_SERVER_ERROR;
-    this.multiErrMsg = multiErrMsg;
+    this.isObject = isObject;
+    this.message = errorMessages;
   }
 }
 
 const handleCustomError = (err, res) => {
-  if (err.multiErrMsg) {
-    const errMsgArr = err.message.split(", ");
-    return res.status(err.statusCode).json({ message: errMsgArr });
-  }
+  // if (err.isObject) {
+  //   const errMsgArr = err.message.split(", ");
+  //   return res.status(err.statusCode).json({ message: errMsgArr });
+  // }
   return res.status(err.statusCode).json({ message: err.message });
 };
 

--- a/src/middlewares/errorHandlerMiddleware.js
+++ b/src/middlewares/errorHandlerMiddleware.js
@@ -9,6 +9,7 @@ const ERROR_MESSAGES = {
   INVALID_TOKEN: "유효하지 않은 토큰입니다.",
   LOGIN_REQUIRED: "로그인이 필요합니다. 로그인 후 이용해주세요.",
   REFRESH_TOKEN_MISMATCH: "refresh token정보가 일치하지 않습니다. 다시 로그인 후 사용해주세요.",
+  REFRESH_TOKEN_RESET_FAILED: "Refresh Token 초기화에 실패했습니다. 다시 로그인 후 사용해주세요.",
   BOOKS_NOT_FOUND: "존재하지 않는 도서입니다.",
   DUPLICATE_EMAIL: "이미 가입된 이메일입니다. 다른 이메일을 입력해주세요.",
   LOGIN_UNAUTHORIZED: "로그인 도중에 문제가 생겼습니다. 로그인을 다시 시도해주세요.",

--- a/src/middlewares/validateMiddleware.js
+++ b/src/middlewares/validateMiddleware.js
@@ -172,6 +172,7 @@ const validateGetBooks = [
   validateRequest,
 ];
 const validateParamBookId = [validateChainIsInt("params", "bookId"), validateRequest];
+const validateParamCartItemId = [validateChainIsInt("params", "cartItemId"), validateRequest];
 const validateGetAddToCart = [
   validateChainIsInt("body", "bookId"),
   validateChainIsInt("body", "quantity"),
@@ -198,7 +199,7 @@ module.exports = {
   validateLikeAndUnlikeBook: validateParamBookId,
   validateGetAddToCart,
   validateGetCartItems,
-  validateRemoveFromCart: validateParamBookId,
+  validateRemoveFromCart: validateParamCartItemId,
   validateRequestPayment,
   validateGetOrderListDetails: validateGetOrderListDetails,
 };

--- a/src/middlewares/validateMiddleware.js
+++ b/src/middlewares/validateMiddleware.js
@@ -16,7 +16,7 @@ const validateRequest = (req, res, next) => {
     return acc;
   }, {});
   console.log(errMsg);
-  return next(new CustomError(errMsg, StatusCodes.BAD_REQUEST, true));
+  return next(new CustomError(errMsg));
 };
 
 /* 유효성 검사 체이닝 */

--- a/src/middlewares/validateMiddleware.js
+++ b/src/middlewares/validateMiddleware.js
@@ -10,12 +10,13 @@ const validateRequest = (req, res, next) => {
     return next();
   }
 
-  console.error(validateErr);
-  const errMsg = validateErr.array().map((obj) => obj.msg);
-  if (errMsg.length > 1) {
-    return next(new CustomError(errMsg, StatusCodes.BAD_REQUEST, true));
-  }
-  return next(new CustomError(errMsg[0], StatusCodes.BAD_REQUEST));
+  // console.error(validateErr.array());
+  const errMsg = validateErr.array().reduce((acc, obj) => {
+    acc[obj.path] = obj.msg;
+    return acc;
+  }, {});
+  console.log(errMsg);
+  return next(new CustomError(errMsg, StatusCodes.BAD_REQUEST, true));
 };
 
 /* 유효성 검사 체이닝 */
@@ -30,8 +31,8 @@ const validateChainOnlyJoinPassword = body("password")
   .notEmpty()
   .withMessage("비밀번호는 필수 입력 정보입니다.")
   .bail()
-  .isLength({ min: 4, max: 16 })
-  .withMessage("비밀번호는 4~16자 이내로 입력해주세요.");
+  .isLength({ min: 8, max: 16 })
+  .withMessage("비밀번호는 8~16자 이내로 입력해주세요.");
 
 const validateChainName = body("name")
   .notEmpty()

--- a/src/middlewares/validateMiddleware.js
+++ b/src/middlewares/validateMiddleware.js
@@ -179,6 +179,11 @@ const validateGetAddToCart = [
   validateRequest,
 ];
 const validateGetCartItems = [validateChainIntArr("selected"), validateRequest];
+const validateChangeQuantityCartItem = [
+  validateChainIsInt("params", "cartItemId"),
+  validateChainIsInt("body", "quantity"),
+  validateRequest,
+];
 const validateRequestPayment = [
   validateChainObjArr("items"),
   validateChainStringObj("delivery"),
@@ -200,6 +205,7 @@ module.exports = {
   validateGetAddToCart,
   validateGetCartItems,
   validateRemoveFromCart: validateParamCartItemId,
+  validateChangeQuantityCartItem,
   validateRequestPayment,
   validateGetOrderListDetails: validateGetOrderListDetails,
 };

--- a/src/routes/aladinBooks.js
+++ b/src/routes/aladinBooks.js
@@ -1,0 +1,9 @@
+const express = require("express");
+const router = express.Router();
+
+const { getAladinBookItem, getAladinBookList } = require("../controllers/aladinBooksController");
+
+router.get("/list", getAladinBookList);
+router.get("/item", getAladinBookItem);
+
+module.exports = router;

--- a/src/routes/aladinBooks.js
+++ b/src/routes/aladinBooks.js
@@ -1,9 +1,10 @@
 const express = require("express");
 const router = express.Router();
 
+const { authenticateToken, refreshAccessToken } = require("../middlewares/authMiddleware");
 const { getAladinBookItem, getAladinBookList } = require("../controllers/aladinBooksController");
 
 router.get("/list", getAladinBookList);
-router.get("/item", getAladinBookItem);
+router.get("/item", authenticateToken, refreshAccessToken, getAladinBookItem);
 
 module.exports = router;

--- a/src/routes/aladinBooks.js
+++ b/src/routes/aladinBooks.js
@@ -2,9 +2,14 @@ const express = require("express");
 const router = express.Router();
 
 const { authenticateToken, refreshAccessToken } = require("../middlewares/authMiddleware");
-const { getAladinBookItem, getAladinBookList } = require("../controllers/aladinBooksController");
+const {
+  getAladinBookItem,
+  getAladinBookList,
+  getSearchAladinBooks,
+} = require("../controllers/aladinBooksController");
 
 router.get("/list", getAladinBookList);
 router.get("/item", authenticateToken, refreshAccessToken, getAladinBookItem);
+router.get("/search", getSearchAladinBooks);
 
 module.exports = router;

--- a/src/routes/carts.js
+++ b/src/routes/carts.js
@@ -7,12 +7,18 @@ const {
   validateRemoveFromCart,
 } = require("../middlewares/validateMiddleware");
 const { authenticateToken, refreshAccessToken } = require("../middlewares/authMiddleware");
-const { addTocart, getCartItems, removeFromCart } = require("../controllers/cartsController");
+const {
+  addTocart,
+  getCartItems,
+  removeFromCart,
+  changeQuantityCartItem,
+} = require("../controllers/cartsController");
 
 router.use(authenticateToken, refreshAccessToken);
 
 router.post("/", validateGetAddToCart, addTocart);
 router.get("/", validateGetCartItems, getCartItems);
 router.delete("/:cartItemId", validateRemoveFromCart, removeFromCart);
+router.put("/:cartItemId", validateRemoveFromCart, changeQuantityCartItem);
 
 module.exports = router;

--- a/src/routes/carts.js
+++ b/src/routes/carts.js
@@ -13,6 +13,6 @@ router.use(authenticateToken, refreshAccessToken);
 
 router.post("/", validateGetAddToCart, addTocart);
 router.get("/", validateGetCartItems, getCartItems);
-router.delete("/:bookId", validateRemoveFromCart, removeFromCart);
+router.delete("/books/:bookId", validateRemoveFromCart, removeFromCart);
 
 module.exports = router;

--- a/src/routes/carts.js
+++ b/src/routes/carts.js
@@ -13,6 +13,6 @@ router.use(authenticateToken, refreshAccessToken);
 
 router.post("/", validateGetAddToCart, addTocart);
 router.get("/", validateGetCartItems, getCartItems);
-router.delete("/books/:bookId", validateRemoveFromCart, removeFromCart);
+router.delete("/:cartItemId", validateRemoveFromCart, removeFromCart);
 
 module.exports = router;

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -7,7 +7,7 @@ const privateKey = process.env.PRIVATE_KEY;
 
 const refreshAccessTokenService = async (userId, refreshToken) => {
   let sql = "SELECT * FROM users WHERE id=? AND refresh_token=?";
-  let values = [+userId, refreshToken];
+  let values = [userId, refreshToken];
   let [results] = await conn.query(sql, values);
   if (results.length > 0) {
     jwt.verify(refreshToken, privateKey);
@@ -24,7 +24,24 @@ const refreshAccessTokenService = async (userId, refreshToken) => {
       return { newAccessToken, newRefreshToken };
     }
   }
-  throw new CustomError(ERROR_MESSAGES.REFRESH_TOKEN_MISMATCH, StatusCodes.UNAUTHORIZED);
+
+  // db에 저장되어 있는 사용자의 Refresh Token과 cookie에 담겨진 Refresh Token이 일치하지 않는 경우
+  // => 토큰 탈취나 변조와 같은 보안상 문제라고 간주하고 db에 저장된 Refresh Token을 초기화시키고 재로그인 유도
+  const isResetRefreshToken = await resetRefreshToken(userId);
+  if (isResetRefreshToken) {
+    // db에 저장된 Refresh Token을 초기화 성공한 경우
+    throw new CustomError(ERROR_MESSAGES.REFRESH_TOKEN_MISMATCH, StatusCodes.UNAUTHORIZED);
+  }
+  // db에 저장된 Refresh Token 초기화 실패한 경우
+  throw new CustomError(ERROR_MESSAGES.REFRESH_TOKEN_RESET_FAILED, StatusCodes.UNAUTHORIZED);
 };
 
-module.exports = { refreshAccessTokenService };
+/* DB에 저장된 해당 사용자의 Refresh Token 초기화 */
+const resetRefreshToken = async (userId) => {
+  const sql = `UPDATE users SET refresh_token=? WHERE id=?`;
+  const values = ["", userId];
+  const [results] = await conn.query(sql, values);
+  return results.affectedRows === 1 ? true : false;
+};
+
+module.exports = { refreshAccessTokenService, resetRefreshToken };

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -1,5 +1,4 @@
 const conn = require("../../database/mariadb").promise();
-const { StatusCodes } = require("http-status-codes");
 const { CustomError, ERROR_MESSAGES } = require("../middlewares/errorHandlerMiddleware");
 const { createToken } = require("../utils/createToken");
 const jwt = require("jsonwebtoken");
@@ -30,10 +29,10 @@ const refreshAccessTokenService = async (userId, refreshToken) => {
   const isResetRefreshToken = await resetRefreshToken(userId);
   if (isResetRefreshToken) {
     // db에 저장된 Refresh Token을 초기화 성공한 경우
-    throw new CustomError(ERROR_MESSAGES.REFRESH_TOKEN_MISMATCH, StatusCodes.UNAUTHORIZED);
+    throw new CustomError(ERROR_MESSAGES.REFRESH_TOKEN_MISMATCH);
   }
   // db에 저장된 Refresh Token 초기화 실패한 경우
-  throw new CustomError(ERROR_MESSAGES.REFRESH_TOKEN_RESET_FAILED, StatusCodes.UNAUTHORIZED);
+  throw new CustomError(ERROR_MESSAGES.REFRESH_TOKEN_RESET_FAILED);
 };
 
 /* DB에 저장된 해당 사용자의 Refresh Token 초기화 */

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -39,7 +39,7 @@ const refreshAccessTokenService = async (userId, refreshToken) => {
 /* DB에 저장된 해당 사용자의 Refresh Token 초기화 */
 const resetRefreshToken = async (userId) => {
   const sql = `UPDATE users SET refresh_token=? WHERE id=?`;
-  const values = ["", userId];
+  const values = [null, userId];
   const [results] = await conn.query(sql, values);
   return results.affectedRows === 1 ? true : false;
 };

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -1,0 +1,30 @@
+const conn = require("../../database/mariadb").promise();
+const { StatusCodes } = require("http-status-codes");
+const { CustomError, ERROR_MESSAGES } = require("../middlewares/errorHandlerMiddleware");
+const { createToken } = require("../utils/createToken");
+const jwt = require("jsonwebtoken");
+const privateKey = process.env.PRIVATE_KEY;
+
+const refreshAccessTokenService = async (userId, refreshToken) => {
+  let sql = "SELECT * FROM users WHERE id=? AND refresh_token=?";
+  let values = [+userId, refreshToken];
+  let [results] = await conn.query(sql, values);
+  if (results.length > 0) {
+    jwt.verify(refreshToken, privateKey);
+
+    const targetUser = results[0];
+    const newAccessToken = createToken("accessToken", targetUser);
+    const newRefreshToken = createToken("refreshToken", targetUser);
+
+    sql = "UPDATE users SET refresh_token=? WHERE id=?";
+    values = [newRefreshToken, targetUser.id];
+    [results] = await conn.query(sql, values);
+
+    if (results.affectedRows === 1) {
+      return { newAccessToken, newRefreshToken };
+    }
+  }
+  throw new CustomError(ERROR_MESSAGES.REFRESH_TOKEN_MISMATCH, StatusCodes.UNAUTHORIZED);
+};
+
+module.exports = { refreshAccessTokenService };

--- a/src/services/booksService.js
+++ b/src/services/booksService.js
@@ -1,5 +1,5 @@
 const conn = require("../../database/mariadb").promise();
-const { snakeToCamelData } = require("../utils/convertSnakeToCamel");
+const { snakeToCamelData } = require("../utils/convert");
 const { CustomError, ERROR_MESSAGES } = require("../middlewares/errorHandlerMiddleware");
 
 const RESPONSE_MESSAGES = {

--- a/src/services/booksService.js
+++ b/src/services/booksService.js
@@ -5,7 +5,7 @@ const { CustomError, ERROR_MESSAGES } = require("../middlewares/errorHandlerMidd
 
 const RESPONSE_MESSAGES = {
   NO_BOOKS: "조회 가능한 도서가 없습니다.",
-  NO_RECENTLY_PUBLISHED_BOOKS: "지난 30일 이내에 출간된 새로운 도서가 없습니다.",
+  NO_RECENTLY_PUBLISHED_BOOKS: "최신 도서가 없습니다.",
 };
 
 const getBooksInfoService = async (categoryId, isNew, page, limit) => {
@@ -62,7 +62,10 @@ const getBooksInfoService = async (categoryId, isNew, page, limit) => {
     throw new CustomError(ERROR_MESSAGES.BAD_REQUEST, StatusCodes.BAD_REQUEST);
   }
 
-  return { data: {}, message };
+  return {
+    data: { books: [], pagination: { totalBooks: 0, page: 1 } },
+    message,
+  };
 };
 
 const getBookDetailService = async (bookId, userId) => {

--- a/src/services/booksService.js
+++ b/src/services/booksService.js
@@ -1,5 +1,4 @@
 const conn = require("../../database/mariadb").promise();
-const { StatusCodes } = require("http-status-codes");
 const { snakeToCamelData } = require("../utils/convertSnakeToCamel");
 const { CustomError, ERROR_MESSAGES } = require("../middlewares/errorHandlerMiddleware");
 
@@ -27,7 +26,7 @@ const getBooksInfoService = async (categoryId, isNew, page, limit) => {
     const preSql = `SELECT * FROM categories WHERE category_id=?`;
     const [preResults] = await conn.query(preSql, [categoryId]);
     if (preResults.length === 0) {
-      throw new CustomError(ERROR_MESSAGES.BAD_REQUEST, StatusCodes.BAD_REQUEST);
+      throw new CustomError(ERROR_MESSAGES.BAD_REQUEST);
     }
     categoryName = preResults[0].category_name;
     values = [categoryId, ...values];
@@ -59,7 +58,7 @@ const getBooksInfoService = async (categoryId, isNew, page, limit) => {
 
   if (page > 1) {
     // 조회 가능한 페이지 번호가 아닌 경우
-    throw new CustomError(ERROR_MESSAGES.BAD_REQUEST, StatusCodes.BAD_REQUEST);
+    throw new CustomError(ERROR_MESSAGES.BAD_REQUEST);
   }
 
   return {
@@ -95,7 +94,7 @@ const getBookDetailService = async (bookId, userId) => {
     data = snakeToCamelData(data);
     return { data };
   }
-  throw new CustomError(ERROR_MESSAGES.BOOKS_NOT_FOUND, StatusCodes.NOT_FOUND);
+  throw new CustomError(ERROR_MESSAGES.BOOKS_NOT_FOUND);
 };
 
 module.exports = { getBooksInfoService, getBookDetailService };

--- a/src/services/booksService.js
+++ b/src/services/booksService.js
@@ -89,7 +89,6 @@ const getBookDetailService = async (bookId, userId) => {
   }
 
   const [results] = await conn.query(sql, values);
-  console.log(results);
   if (results.length > 0) {
     // let data = Object.fromEntries(Object.entries(results[0]));
     data = snakeToCamelData(results[0]);

--- a/src/services/booksService.js
+++ b/src/services/booksService.js
@@ -9,14 +9,14 @@ const RESPONSE_MESSAGES = {
 
 const getBooksInfoService = async (categoryId, isNew, page, limit) => {
   const baseSql = `SELECT b.*, c.category_name,
-                    (SELECT count(*) FROM likes WHERE likes.liked_book_id=b.id) AS likes,
-                    (SELECT count(*) FROM books) AS total_books
+                    (SELECT count(*) FROM likes WHERE likes.liked_book_id=b.id) AS likes
                   FROM books AS b INNER JOIN categories AS c USING (category_id)`;
   const categorySql = "category_id=?";
   const isNewBookSql = "published_date BETWEEN DATE_SUB(CURDATE(), INTERVAL 30 DAY) AND CURDATE()";
   const tailSql = " LIMIT ? OFFSET ?";
 
   let sql = `${baseSql} ${tailSql}`; // 전체 도서 목록 조회
+  let totalBookSql = baseSql;
   let message = RESPONSE_MESSAGES.NO_BOOKS;
   const offset = (page - 1) * limit;
   let values = [limit, offset];
@@ -34,25 +34,27 @@ const getBooksInfoService = async (categoryId, isNew, page, limit) => {
 
   if (categoryId && isNew) {
     // 카테고리 별 신간 도서 목록 조회 (출판일이 현재 일자 기준으로 30일 이내인 도서)
-    sql = `${baseSql} WHERE ${categorySql} AND ${isNewBookSql} ${tailSql}`;
+    totalBookSql = `${baseSql} WHERE ${categorySql} AND ${isNewBookSql}`;
+    sql = `${totalBookSql} ${tailSql}`;
     message = `${categoryName} 카테고리에는 ${RESPONSE_MESSAGES.NO_RECENTLY_PUBLISHED_BOOKS}`;
   } else if (categoryId && !isNew) {
     // 카테고리 별 도서 목록 조회
-    sql = `${baseSql} WHERE ${categorySql} ${tailSql}`;
+    totalBookSql = `${baseSql} WHERE ${categorySql}`;
+    sql = `${totalBookSql} ${tailSql}`;
     message = `${categoryName} 카테고리에는 ${RESPONSE_MESSAGES.NO_BOOKS}`;
   } else if (!categoryId && isNew) {
     // 신간 도서 목록 조회 (전체 카테고리 통합)
-    sql = `${baseSql} WHERE ${isNewBookSql} ${tailSql}`;
+    totalBookSql = `${baseSql} WHERE ${isNewBookSql}`;
+    sql = `${totalBookSql} ${tailSql}`;
     message = RESPONSE_MESSAGES.NO_RECENTLY_PUBLISHED_BOOKS;
   }
 
+  const [totalBookResult] = await conn.query(totalBookSql, values);
+  const totalBooks = totalBookResult.length;
+
   const [results] = await conn.query(sql, values);
   if (results.length > 0) {
-    const totalBooks = results[0].total_books;
-    let books = Object.entries(results)
-      .filter(([key]) => key !== "category_id")
-      .map((arr) => arr[1]);
-    books = snakeToCamelData(books);
+    const books = snakeToCamelData(results);
     return { data: { books, pagination: { totalBooks, page } }, message: null };
   }
 
@@ -87,11 +89,10 @@ const getBookDetailService = async (bookId, userId) => {
   }
 
   const [results] = await conn.query(sql, values);
+  console.log(results);
   if (results.length > 0) {
-    let data = Object.fromEntries(
-      Object.entries(results[0]).filter(([key]) => key !== "category_id"),
-    );
-    data = snakeToCamelData(data);
+    // let data = Object.fromEntries(Object.entries(results[0]));
+    data = snakeToCamelData(results[0]);
     return { data };
   }
   throw new CustomError(ERROR_MESSAGES.BOOKS_NOT_FOUND);

--- a/src/services/cartsService.js
+++ b/src/services/cartsService.js
@@ -65,9 +65,9 @@ const getCartItemsService = async (cartItemIds, userId) => {
   return { data: {}, message: RESPONSE_MESSAGES.EMPTY_CART };
 };
 
-const removeFromCartService = async (bookId, userId) => {
-  const sql = `DELETE FROM cart_items WHERE user_id=? AND book_id=?`;
-  const values = [+userId, +bookId];
+const removeFromCartService = async (cartItemId, userId) => {
+  const sql = `DELETE FROM cart_items WHERE user_id=? AND id=?`;
+  const values = [+userId, +cartItemId];
   const [results] = await conn.query(sql, values);
   if (results.affectedRows > 0) {
     return null;

--- a/src/services/cartsService.js
+++ b/src/services/cartsService.js
@@ -29,7 +29,10 @@ const addTocartService = async (bookId, quantity, userId) => {
     values = [setQuantity, userId, bookId];
     [results] = await conn.query(sql, values);
     if (results.affectedRows > 0) {
-      return { message: RESPONSE_MESSAGES.ADD_TO_CART };
+      sql = "SELECT count(*) as cnt FROM cart_items WHERE user_id=?";
+      values = [userId];
+      [results] = await conn.query(sql, values);
+      return { data: { cartItemsCount: results[0].cnt }, message: RESPONSE_MESSAGES.ADD_TO_CART };
     }
     throw new CustomError(ERROR_MESSAGES.BAD_REQUEST);
   }
@@ -39,7 +42,7 @@ const addTocartService = async (bookId, quantity, userId) => {
 
 const getCartItemsService = async (cartItemIds, userId) => {
   // 장바구니 전체 목록 조회
-  const sql = `SELECT c.id AS cart_item_id, c.book_id, b.title, b.summary, b.price, c.quantity 
+  const sql = `SELECT c.id AS cart_item_id, c.book_id, b.title, b.summary, b.price, b.img_url, c.quantity 
               FROM cart_items AS c INNER JOIN books AS b ON c.book_id = b.id 
               WHERE c.user_id=?`;
   const tailSql = " AND c.id IN (?)";
@@ -62,7 +65,7 @@ const getCartItemsService = async (cartItemIds, userId) => {
     const items = snakeToCamelData(results);
     return { data: { items }, message: null };
   }
-  return { data: {}, message: RESPONSE_MESSAGES.EMPTY_CART };
+  return { data: { items: [] }, message: RESPONSE_MESSAGES.EMPTY_CART };
 };
 
 const removeFromCartService = async (cartItemId, userId) => {

--- a/src/services/cartsService.js
+++ b/src/services/cartsService.js
@@ -1,5 +1,5 @@
 const conn = require("../../database/mariadb").promise();
-const { snakeToCamelData } = require("../utils/convertSnakeToCamel");
+const { snakeToCamelData } = require("../utils/convert");
 const { CustomError, ERROR_MESSAGES } = require("../middlewares/errorHandlerMiddleware");
 
 const RESPONSE_MESSAGES = {

--- a/src/services/cartsService.js
+++ b/src/services/cartsService.js
@@ -1,6 +1,7 @@
 const conn = require("../../database/mariadb").promise();
 const { snakeToCamelData } = require("../utils/convert");
 const { CustomError, ERROR_MESSAGES } = require("../middlewares/errorHandlerMiddleware");
+const { insertBookInfoService } = require("./likesService");
 
 const RESPONSE_MESSAGES = {
   ADD_TO_CART: "장바구니에 추가되었습니다.",
@@ -8,8 +9,10 @@ const RESPONSE_MESSAGES = {
   CHANGE_CART_ITEM_QUANTITY: "수량을 변경하였습니다.",
 };
 
-const addTocartService = async (bookId, quantity, userId) => {
-  let sql = "SELECT * FROM books WHERE id=?";
+const addTocartService = async (bookId, quantity, userId, info) => {
+  await insertBookInfoService(bookId, info);
+
+  let sql = "SELECT * FROM aladin_books WHERE item_id=?";
   let [results] = await conn.query(sql, [bookId]);
   if (results.length > 0) {
     // 동일한 물품이 장바구니에 존재하는지 확인
@@ -43,8 +46,8 @@ const addTocartService = async (bookId, quantity, userId) => {
 
 const getCartItemsService = async (cartItemIds, userId) => {
   // 장바구니 전체 목록 조회
-  const sql = `SELECT c.id AS cart_item_id, c.book_id, b.title, b.summary, b.price, b.img_url, c.quantity 
-              FROM cart_items AS c INNER JOIN books AS b ON c.book_id = b.id 
+  const sql = `SELECT c.id AS cart_item_id, c.book_id, b.title, b.price_standard, b.cover, c.quantity 
+              FROM cart_items AS c INNER JOIN aladin_books AS b ON c.book_id = b.item_id 
               WHERE c.user_id=?`;
   const tailSql = " AND c.id IN (?)";
   let values = [userId];

--- a/src/services/cartsService.js
+++ b/src/services/cartsService.js
@@ -5,6 +5,7 @@ const { CustomError, ERROR_MESSAGES } = require("../middlewares/errorHandlerMidd
 const RESPONSE_MESSAGES = {
   ADD_TO_CART: "장바구니에 추가되었습니다.",
   EMPTY_CART: "장바구니 목록이 비어있습니다.",
+  CHANGE_CART_ITEM_QUANTITY: "수량을 변경하였습니다.",
 };
 
 const addTocartService = async (bookId, quantity, userId) => {
@@ -70,10 +71,20 @@ const getCartItemsService = async (cartItemIds, userId) => {
 
 const removeFromCartService = async (cartItemId, userId) => {
   const sql = `DELETE FROM cart_items WHERE user_id=? AND id=?`;
-  const values = [+userId, +cartItemId];
+  const values = [userId, cartItemId];
   const [results] = await conn.query(sql, values);
   if (results.affectedRows > 0) {
     return null;
+  }
+  throw new CustomError(ERROR_MESSAGES.BAD_REQUEST);
+};
+
+const changeQuantityCartItemService = async (cartItemId, quantity, userId) => {
+  const sql = `UPDATE cart_items SET quantity=? WHERE user_id=? AND id=?`;
+  const values = [quantity, userId, cartItemId];
+  const [results] = await conn.query(sql, values);
+  if (results.affectedRows > 0) {
+    return { message: RESPONSE_MESSAGES.CHANGE_CART_ITEM_QUANTITY };
   }
   throw new CustomError(ERROR_MESSAGES.BAD_REQUEST);
 };
@@ -82,4 +93,5 @@ module.exports = {
   addTocartService,
   getCartItemsService,
   removeFromCartService,
+  changeQuantityCartItemService,
 };

--- a/src/services/cartsService.js
+++ b/src/services/cartsService.js
@@ -1,5 +1,4 @@
 const conn = require("../../database/mariadb").promise();
-const { StatusCodes } = require("http-status-codes");
 const { snakeToCamelData } = require("../utils/convertSnakeToCamel");
 const { CustomError, ERROR_MESSAGES } = require("../middlewares/errorHandlerMiddleware");
 
@@ -32,10 +31,10 @@ const addTocartService = async (bookId, quantity, userId) => {
     if (results.affectedRows > 0) {
       return { message: RESPONSE_MESSAGES.ADD_TO_CART };
     }
-    throw new CustomError(ERROR_MESSAGES.BAD_REQUEST, StatusCodes.BAD_REQUEST);
+    throw new CustomError(ERROR_MESSAGES.BAD_REQUEST);
   }
 
-  throw new CustomError(ERROR_MESSAGES.BOOKS_NOT_FOUND, StatusCodes.NOT_FOUND);
+  throw new CustomError(ERROR_MESSAGES.BOOKS_NOT_FOUND);
 };
 
 const getCartItemsService = async (cartItemIds, userId) => {
@@ -55,7 +54,7 @@ const getCartItemsService = async (cartItemIds, userId) => {
       const items = snakeToCamelData(selectedItemsResults);
       return { data: { items }, message: null };
     }
-    throw new CustomError(ERROR_MESSAGES.BAD_REQUEST, StatusCodes.BAD_REQUEST);
+    throw new CustomError(ERROR_MESSAGES.BAD_REQUEST);
   }
 
   const [results] = await conn.query(sql, values);
@@ -73,7 +72,7 @@ const removeFromCartService = async (bookId, userId) => {
   if (results.affectedRows > 0) {
     return null;
   }
-  throw new CustomError(ERROR_MESSAGES.BAD_REQUEST, StatusCodes.BAD_REQUEST);
+  throw new CustomError(ERROR_MESSAGES.BAD_REQUEST);
 };
 
 module.exports = {

--- a/src/services/categoriesService.js
+++ b/src/services/categoriesService.js
@@ -9,7 +9,8 @@ const getAllCategoriesService = async () => {
   const sql = `SELECT * FROM categories`;
   const [results] = await conn.query(sql);
   if (results.length > 0) {
-    const categories = snakeToCamelData(results);
+    const totalCategories = snakeToCamelData(results);
+    const categories = totalCategories.filter((item) => item.categoryName !== "페이크");
     return { data: { categories }, message: null };
   }
   return { data: { categories: [] }, message: RESPONSE_MESSAGES.EMPTY_CATEGORY_LIST };

--- a/src/services/categoriesService.js
+++ b/src/services/categoriesService.js
@@ -12,7 +12,7 @@ const getAllCategoriesService = async () => {
     const categories = snakeToCamelData(results);
     return { data: { categories }, message: null };
   }
-  return { data: {}, message: RESPONSE_MESSAGES.EMPTY_CATEGORY_LIST };
+  return { data: { categories: [] }, message: RESPONSE_MESSAGES.EMPTY_CATEGORY_LIST };
 };
 
 module.exports = { getAllCategoriesService };

--- a/src/services/categoriesService.js
+++ b/src/services/categoriesService.js
@@ -1,5 +1,5 @@
 const conn = require("../../database/mariadb").promise();
-const { snakeToCamelData } = require("../utils/convertSnakeToCamel");
+const { snakeToCamelData } = require("../utils/convert");
 
 const RESPONSE_MESSAGES = {
   EMPTY_CATEGORY_LIST: "카테고리 목록이 비어있습니다.",

--- a/src/services/likesService.js
+++ b/src/services/likesService.js
@@ -2,8 +2,8 @@ const conn = require("../../database/mariadb").promise();
 const { CustomError } = require("../middlewares/errorHandlerMiddleware");
 
 const RESPONSE_MESSAGES = {
-  LIKED: "좋아요 추가!",
-  UNLIKED: "좋아요 취소!",
+  LIKED: "liked",
+  UNLIKED: "unliked",
 };
 
 const likeAndUnlikeBookService = async (bookId, userId) => {

--- a/src/services/likesService.js
+++ b/src/services/likesService.js
@@ -1,9 +1,41 @@
 const conn = require("../../database/mariadb").promise();
 const { CustomError } = require("../middlewares/errorHandlerMiddleware");
+const { camelToSnakeData } = require("../utils/convert");
 
 const RESPONSE_MESSAGES = {
   LIKED: "liked",
   UNLIKED: "unliked",
+};
+
+const insertBookInfoService = async (bookId, info) => {
+  const isExistedBookInfoSql = "SELECT COUNT(*) AS count FROM aladin_books WHERE item_id=?";
+  let [results] = await conn.query(isExistedBookInfoSql, [bookId]);
+  if (results[0].count === 0) {
+    const insertBookSql =
+      "INSERT INTO aladin_books (item_id, title, category_id, description, author, price_standard, pub_date, cover, form, isbn13, publisher, item_page, rating_score, rating_count, my_review_count, best_seller_rank) VALUES ?";
+    const bookInfo = camelToSnakeData(info);
+    const values = [
+      [
+        bookInfo.item_id,
+        bookInfo.title,
+        bookInfo.category_id,
+        bookInfo.description,
+        bookInfo.author,
+        bookInfo.price_standard,
+        bookInfo.pub_date,
+        bookInfo.cover,
+        bookInfo.form,
+        bookInfo.isbn13,
+        bookInfo.publisher,
+        bookInfo.item_page,
+        bookInfo.rating_score,
+        bookInfo.rating_count,
+        bookInfo.my_review_count,
+        bookInfo.best_seller_rank,
+      ],
+    ];
+    await conn.query(insertBookSql, [values]);
+  }
 };
 
 const likeAndUnlikeBookService = async (bookId, userId) => {
@@ -34,4 +66,4 @@ const likeAndUnlikeBookService = async (bookId, userId) => {
   throw new CustomError(ERROR_MESSAGES.BAD_REQUEST);
 };
 
-module.exports = { likeAndUnlikeBookService };
+module.exports = { likeAndUnlikeBookService, insertBookInfoService };

--- a/src/services/likesService.js
+++ b/src/services/likesService.js
@@ -1,5 +1,4 @@
 const conn = require("../../database/mariadb").promise();
-const { StatusCodes } = require("http-status-codes");
 const { CustomError } = require("../middlewares/errorHandlerMiddleware");
 
 const RESPONSE_MESSAGES = {
@@ -32,7 +31,7 @@ const likeAndUnlikeBookService = async (bookId, userId) => {
       return { data: { likes }, message: RESPONSE_MESSAGES.LIKED };
     }
   }
-  throw new CustomError(ERROR_MESSAGES.BAD_REQUEST, StatusCodes.BAD_REQUEST);
+  throw new CustomError(ERROR_MESSAGES.BAD_REQUEST);
 };
 
 module.exports = { likeAndUnlikeBookService };

--- a/src/services/likesService.js
+++ b/src/services/likesService.js
@@ -66,4 +66,28 @@ const likeAndUnlikeBookService = async (bookId, userId) => {
   throw new CustomError(ERROR_MESSAGES.BAD_REQUEST);
 };
 
-module.exports = { likeAndUnlikeBookService, insertBookInfoService };
+const likesCountService = async (bookId) => {
+  const likeCountSql = "SELECT COUNT(*) AS likes FROM likes WHERE liked_book_id=?";
+  let [results] = await conn.query(likeCountSql, [bookId]);
+  return { likes: results[0].likes };
+};
+
+const isLikedService = async (bookId, userId) => {
+  if (userId) {
+    // 로그인한 유저가 개별 도서 조회 api를 호출한 경우(accessToken 유효성 검증 과정이 선행됨)
+    const sql = `SELECT EXISTS (SELECT 1 FROM likes WHERE user_id = ? AND liked_book_id = ?) AS is_liked`;
+    const [results] = await conn.query(sql, [userId, bookId]);
+    if (results.length > 0) {
+      return { isLiked: results[0].is_liked };
+    }
+  } else return { isLiked: false };
+
+  throw new CustomError(ERROR_MESSAGES.BOOKS_NOT_FOUND);
+};
+
+module.exports = {
+  likeAndUnlikeBookService,
+  insertBookInfoService,
+  likesCountService,
+  isLikedService,
+};

--- a/src/services/ordersService.js
+++ b/src/services/ordersService.js
@@ -113,7 +113,7 @@ const getOrderListDetailsService = async (orderId, userId) => {
   const values = [orderId, userId];
   const [results] = await conn.query(sql, values);
   if (results.length > 0) {
-    sql = `SELECT o.book_id, b.title, b.author, b.price, o.quantity 
+    sql = `SELECT o.book_id, b.title, b.author, b.price, b.img_url, b.form, o.quantity 
             FROM ordered_books AS o INNER JOIN books AS b ON o.book_id=b.id 
             WHERE order_id =?`;
     const [results] = await conn.query(sql, orderId);

--- a/src/services/ordersService.js
+++ b/src/services/ordersService.js
@@ -1,5 +1,5 @@
 const conn = require("../../database/mariadb").promise();
-const { snakeToCamelData } = require("../utils/convertSnakeToCamel");
+const { snakeToCamelData } = require("../utils/convert");
 const { CustomError, ERROR_MESSAGES } = require("../middlewares/errorHandlerMiddleware");
 
 const RESPONSE_MESSAGES = {

--- a/src/services/ordersService.js
+++ b/src/services/ordersService.js
@@ -1,5 +1,4 @@
 const conn = require("../../database/mariadb").promise();
-const { StatusCodes } = require("http-status-codes");
 const { snakeToCamelData } = require("../utils/convertSnakeToCamel");
 const { CustomError, ERROR_MESSAGES } = require("../middlewares/errorHandlerMiddleware");
 
@@ -13,7 +12,7 @@ const checkDataMatch = async (conn, items, itemIds, userId, totalQuantity) => {
   const values = [userId, itemIds];
   const [checkResults] = await conn.query(sql, values);
   if (checkResults.length !== itemIds.length) {
-    throw new CustomError(ERROR_MESSAGES.CART_DATA_MISMATCH, StatusCodes.BAD_REQUEST);
+    throw new CustomError(ERROR_MESSAGES.CART_DATA_MISMATCH);
   }
 
   const requestItems = [...items].sort((obj1, obj2) => obj1.cartItemId - obj2.cartItemId);
@@ -25,13 +24,13 @@ const checkDataMatch = async (conn, items, itemIds, userId, totalQuantity) => {
       checkResults[i].book_id !== bookId ||
       checkResults[i].quantity !== quantity
     ) {
-      throw new CustomError(ERROR_MESSAGES.CART_DATA_MISMATCH, StatusCodes.BAD_REQUEST);
+      throw new CustomError(ERROR_MESSAGES.CART_DATA_MISMATCH);
     }
   }
 
   const checkTotalQuantity = checkResults.reduce((acc, obj) => acc + obj.quantity, 0);
   if (checkTotalQuantity !== totalQuantity) {
-    throw new CustomError(ERROR_MESSAGES.CART_DATA_MISMATCH, StatusCodes.BAD_REQUEST);
+    throw new CustomError(ERROR_MESSAGES.CART_DATA_MISMATCH);
   }
 };
 
@@ -69,7 +68,7 @@ const requestPaymentService = async (
     sql = "DELETE FROM cart_items WHERE id IN(?)";
     const [deleteResults] = await conn.query(sql, [itemIds]);
     if (deleteResults.affectedRows !== items.length) {
-      throw new CustomError(ERROR_MESSAGES.ORDER_ERROR, StatusCodes.BAD_REQUEST);
+      throw new CustomError(ERROR_MESSAGES.ORDER_ERROR);
     }
 
     await conn.commit();
@@ -77,7 +76,7 @@ const requestPaymentService = async (
     return { message: RESPONSE_MESSAGES.ORDER_SUCCESS };
   } catch (err) {
     await conn.rollback();
-    throw new CustomError(err.message, StatusCodes.BAD_REQUEST);
+    throw new CustomError(err.message);
   }
 };
 
@@ -123,7 +122,7 @@ const getOrderListDetailsService = async (orderId, userId) => {
       return { data: { orderDetail } };
     }
   }
-  throw new CustomError(ERROR_MESSAGES.BAD_REQUEST, StatusCodes.BAD_REQUEST);
+  throw new CustomError(ERROR_MESSAGES.BAD_REQUEST);
 };
 
 module.exports = { requestPaymentService, getOrderListService, getOrderListDetailsService };

--- a/src/services/ordersService.js
+++ b/src/services/ordersService.js
@@ -113,8 +113,8 @@ const getOrderListDetailsService = async (orderId, userId) => {
   const values = [orderId, userId];
   const [results] = await conn.query(sql, values);
   if (results.length > 0) {
-    sql = `SELECT o.book_id, b.title, b.author, b.price, b.img_url, b.form, o.quantity 
-            FROM ordered_books AS o INNER JOIN books AS b ON o.book_id=b.id 
+    sql = `SELECT o.book_id, b.title, b.author, b.price_standard, b.cover, b.form, o.quantity 
+            FROM ordered_books AS o INNER JOIN aladin_books AS b ON o.book_id=b.item_id 
             WHERE order_id =?`;
     const [results] = await conn.query(sql, orderId);
     if (results.length > 0) {

--- a/src/services/usersService.js
+++ b/src/services/usersService.js
@@ -8,7 +8,7 @@ const { resetRefreshToken } = require("./authService");
 const RESPONSE_MESSAGES = {
   JOIN_SUCCESS: "회원가입이 완료되었습니다. 로그인을 진행해주세요.",
   LOGOUT_SUCCESS: "로그아웃 되었습니다.",
-  RESET_PASSWORD: "비밀번호가 변경되었습니다.",
+  RESET_PASSWORD: "비밀번호가 변경되었습니다. 로그인을 진행해주세요.",
 };
 
 const joinService = async (email, password, name, contact) => {

--- a/src/services/usersService.js
+++ b/src/services/usersService.js
@@ -1,5 +1,4 @@
 const conn = require("../../database/mariadb").promise();
-const { StatusCodes } = require("http-status-codes");
 const { CustomError, ERROR_MESSAGES } = require("../middlewares/errorHandlerMiddleware");
 const { encryptPassword } = require("../utils/encryptPassword");
 const { createToken } = require("../utils/createToken");
@@ -16,7 +15,7 @@ const joinService = async (email, password, name, contact) => {
   let sql = `SELECT * FROM users WHERE email = ?`;
   let [results] = await conn.query(sql, [email]);
   if (results.length > 0) {
-    throw new CustomError(ERROR_MESSAGES.DUPLICATE_EMAIL, StatusCodes.BAD_REQUEST);
+    throw new CustomError(ERROR_MESSAGES.DUPLICATE_EMAIL);
   }
 
   // 비밀번호 암호화
@@ -28,7 +27,7 @@ const joinService = async (email, password, name, contact) => {
   if (results.affectedRows === 1) {
     return { message: RESPONSE_MESSAGES.JOIN_SUCCESS };
   }
-  throw new CustomError(ERROR_MESSAGES.BAD_REQUEST, StatusCodes.BAD_REQUEST);
+  throw new CustomError(ERROR_MESSAGES.BAD_REQUEST);
 };
 
 /* 로그인 */
@@ -62,11 +61,11 @@ const loginService = async (email, password) => {
           refreshToken,
         };
       }
-      throw new CustomError(ERROR_MESSAGES.LOGIN_UNAUTHORIZED, StatusCodes.UNAUTHORIZED);
+      throw new CustomError(ERROR_MESSAGES.LOGIN_UNAUTHORIZED);
     }
   }
 
-  throw new CustomError(ERROR_MESSAGES.LOGIN_BAD_REQUEST, StatusCodes.BAD_REQUEST);
+  throw new CustomError(ERROR_MESSAGES.LOGIN_BAD_REQUEST);
 };
 
 /* 로그아웃 */
@@ -76,7 +75,7 @@ const logoutService = async (userId) => {
     return { message: RESPONSE_MESSAGES.LOGOUT_SUCCESS };
   }
 
-  throw new CustomError(ERROR_MESSAGES.BAD_REQUEST, StatusCodes.BAD_REQUEST);
+  throw new CustomError(ERROR_MESSAGES.BAD_REQUEST);
 };
 
 /* 비밀번호 초기화 요청(로그인 하기 전, 비밀번호 찾기 기능) */
@@ -88,7 +87,7 @@ const requestPwdResetService = async (email) => {
     return { data: { email: targetUser.email } };
   }
 
-  throw new CustomError(ERROR_MESSAGES.EMAIL_NOT_FOUND, StatusCodes.NOT_FOUND);
+  throw new CustomError(ERROR_MESSAGES.EMAIL_NOT_FOUND);
 };
 
 /* 비밀번호 초기화(새로운 비밀번호로 변경하는 기능) */
@@ -102,7 +101,7 @@ const performPwdResetService = async (email, newPW) => {
     return { message: RESPONSE_MESSAGES.RESET_PASSWORD };
   }
 
-  throw new CustomError(ERROR_MESSAGES.BAD_REQUEST, StatusCodes.BAD_REQUEST);
+  throw new CustomError(ERROR_MESSAGES.BAD_REQUEST);
 };
 
 module.exports = {

--- a/src/services/usersService.js
+++ b/src/services/usersService.js
@@ -3,6 +3,7 @@ const { StatusCodes } = require("http-status-codes");
 const { CustomError, ERROR_MESSAGES } = require("../middlewares/errorHandlerMiddleware");
 const { encryptPassword } = require("../utils/encryptPassword");
 const { createToken } = require("../utils/createToken");
+const { resetRefreshToken } = require("./authService");
 
 const RESPONSE_MESSAGES = {
   JOIN_SUCCESS: "회원가입이 완료되었습니다. 로그인을 진행해주세요.",
@@ -68,11 +69,10 @@ const loginService = async (email, password) => {
   throw new CustomError(ERROR_MESSAGES.LOGIN_BAD_REQUEST, StatusCodes.BAD_REQUEST);
 };
 
+/* 로그아웃 */
 const logoutService = async (userId) => {
-  const sql = `UPDATE users SET refresh_token=? WHERE id=?`;
-  const values = ["", userId];
-  const [results] = await conn.query(sql, values);
-  if (results.affectedRows === 1) {
+  const resetRefreshToken = await resetRefreshToken();
+  if (resetRefreshToken) {
     return { message: RESPONSE_MESSAGES.LOGOUT_SUCCESS };
   }
 

--- a/src/services/usersService.js
+++ b/src/services/usersService.js
@@ -71,8 +71,8 @@ const loginService = async (email, password) => {
 
 /* 로그아웃 */
 const logoutService = async (userId) => {
-  const resetRefreshToken = await resetRefreshToken();
-  if (resetRefreshToken) {
+  const isResetRefreshToken = await resetRefreshToken(userId);
+  if (isResetRefreshToken) {
     return { message: RESPONSE_MESSAGES.LOGOUT_SUCCESS };
   }
 

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -17,4 +17,17 @@ const snakeToCamelData = (data) => {
   }
 };
 
-module.exports = { snakeToCamelData };
+const camelToSnakeData = (data) => {
+  console.log(data);
+  if (typeof data !== "object" || data === null) {
+    return data;
+  }
+
+  return Object.keys(data).reduce((acc, key) => {
+    const newKey = key.replace(/([A-Z])/g, "_$1").toLowerCase();
+    acc[newKey] = data[key];
+    return acc;
+  }, {});
+};
+
+module.exports = { snakeToCamelData, camelToSnakeData };

--- a/src/utils/createToken.js
+++ b/src/utils/createToken.js
@@ -1,8 +1,8 @@
 const jwt = require("jsonwebtoken");
 require("dotenv").config();
-const privateKey = process.env.PRIVATE_KEY;
 
 const createToken = (type, user) => {
+  const privateKey = process.env.PRIVATE_KEY;
   const { email, id: uid } = user;
   const tokenData = {
     accessToken: { email, uid },

--- a/src/utils/createToken.js
+++ b/src/utils/createToken.js
@@ -9,11 +9,11 @@ const createToken = (type, user) => {
     refreshToken: { uid },
   };
   const tokenConfig = {
-    accessTokenConfig: {
+    accessToken: {
       expiresIn: process.env.ACCESSTOKEN_LIFETIME,
       issuer: process.env.ACCESSTOKEN_ISSUER,
     },
-    refreshTokenConfig: {
+    refreshToken: {
       expiresIn: process.env.REFRESHTOKEN_LIFETIME,
       issuer: process.env.REFRESHTOKEN_ISSUER,
     },


### PR DESCRIPTION
## 관련 이슈 번호
Closed #5

## 추가한 기능
### 1) 장바구니 수량 변경 기능 추가
### 2) 알라딘 오픈 api를 사용한 도서 조회 기능 추가
- 기존의 DB에 저장되어 있는 books 테이블에 담긴 임의의 도서 데이터가 아닌 실제 도서 데이터를 보여주기 위함
### 3) 도서 검색 기능 추가
- aladin api를 이용하여 상품 조회 api 요청 수행
## 리팩토링 작업한 내용
### 1) authMiddleware에서 서비스 로직을 authService로 분리
### 2) cookie에 담겨진 refresh token과 DB에 저장되어 있는 Refresh Token 정보가 일치하지 않는 경우에 대한 핸들링 추가
- access token이 만료된 경우에만 refresh token의 일치여부 및 유효성을 검사함
- refresh token이 불일치 하는 경우에 대한 2가지 시나리오
  i) 과거에 이미 만료된 access token과 유효한 refresh token을 함께 탈취 당했고 이 공격자의 요청을 처리한 적이 있음. 따라서, DB에 저장되어 있던 refresh token이 갱신 되어버린 상태임. 이후, 진짜 사용자의 요청이 들어온 경우 DB에 저장되어 있는 refresh token과 사용자 요청의 쿠키에 담긴 refresh token의 불일치가 발생함(쿠키에 refresh token은 존재하면서 만료된 access token으로 사용자의 요청이 들어온 경우에 해당됨)
  ii) 만료된 access token이 탈취당했고 변조된 refresh token으로 공격자의 요청이 들어온 경우
- 위의 상황들은 모두 보안상 문제가 발생하였다고 판단
- 따라서, DB에 저장된 해당 사용자의 Refresh Token 값을 초기화 시키고 재로그인을 유도하도록 로직을 수정
### 3) 응답 데이터 형식 수정
- data 필드에 담아서 보냈으나, 프론트에서 데이터를 꺼내기 쉽게 하기위해 data 필드를 삭제하고 data를 JSON에 바로 담아서 전송

### 4) 유효성 검사 미들웨어 수정
- 전달되는 에러 메세지 타입은 객체형태로 전송
- 여러개의 에러가 발생한경우, path(ex. name, email 등)와 발생한 에러 내용을 객체에 담아서 전송

### 5) 에러 핸들러 미들웨어 수정
- 유효성 검사 미들웨어에서 전송되는 에러 메세지는 객체형태 또는 string 형태다.
- 따라서, 전달되는 에러 메세지 타입을 배열 형태(수정전)가 아닌 객체 형태로 수정

### 6) cors 설정
- cors 모듈 설치
- origin (허용할 출처) : 프론트
- credentials : 인증을 위한 정보(쿠키, 요청 헤더의 인증 정보)들을 주고 받도록 설정
- 프론트에서 Authorization 헤더를 읽을 수 있도록 cors 설정 추가

### 7) auth 미들웨어
- user 테이블에 저장된 refresh token 초기화 시, 빈문자열('')이 아니라 null을 저장하도록 수정

### 8) 도서 목록 조회 api
- 조회된 도서가 없을 경우, 전달되는 데이터 포맷이 빈 객체가 아니라 books는 빈 배열, pagination의 totalBooks는 0, page는 1을 담아서 전송하도록 수정, 관련 메세지도 함께 전송

### 9) 에러 핸들러 미들웨어 수정
- 각 Service에서 커스텀 에러를 던질 때 에러 메세지만 던지고 상태코드는 에러 핸들러 미들웨어에서 결정하도록 수정
- 커스텀 에러의 경우, switch문으로 에러 메세지에 대한 에러 상태코드를 설정하여 응답하도록 구현

### 10) 장바구니 제거 엔드포인트 수정
- 수정 전: '/api/cart/:bookId'
- 수정 후: '/api/cart/books/:bookId'
- 수정한 이유: /cart 뒤에 붙는 id 파라미터 값이 장바구니 id가 아니라 book id기 때문에 books를 엔드포인트에 추가하여 id 파라미터는 cart id가 아니라  book id임을 명확하게 하기 위해

### 11) 도서 조회 api 수정
- 도서 조회 시, category_id도 포함시켜서 응답 데이터 전달
- 전체 도서 조회 및 카테고리, 신간도서 조회 시, 조회된 결과에 대한 totalBooks구하는 query를 따로 수행. 기존에는 books 테이블에 있는 전체 도서 총 개수만 구했었는데 프론트에서 조회된 결과의 총 도서수에 대한 page를 계산해야 하므로 조회된 결과에 대한 전체 도서수를 전달하도록 수정

### 12) 장바구니 삭제 요청 엔드포인트 수정
1. 프론트에서 장바구니 삭제할 때 전달하는 경로 파라미터를 bookId가 아니라 cartItemId를 전달하도록 설계함
  - 수정 전 엔드포인트 : /carts/books/:bookId
  - 수정 후 엔드포인트 : /carts/:cartItemId

2. 장바구니 삭제 요청 시 유효성 검사 항목 수정
  - 수정 전 : params에 bookId를 검사
  - 수정 후 : params에 cartItemId를 검사

3. 프론트로 전달하는 데이터 포맷 수정
- 저번에 일괄적으로 data형식을 수정했는데 장바구니 제거에서는 누락되어서 수정함
- data라는 필드를 새로 만들어서 data필드에 결과데이터를 담아서 전송하지 않고 결과 데이터를 그대로 전달  

### 13) 장바구니 추가 요청 시 장바구니 아이템 수량 데이터도 함께 전송하도록 수정, 상세 주문 조회 요청 시 img_url과 form 데이터도 추가해서 응답하도록 수정

### 14) 좋아요 추가 및 취소 기능 로직 수정
1. 도서 데이터를 프론트 측으로 응답 보내는 방법 수정
  - 프론트에서 도서 조회 요청을 보내면, 서버에서는 도서 데이터를 알라딘 오픈 api를 통해 받아서 프론트 측으로 도서 data를 전달해주도록 로직을 수정(이전 커밋 작업 내역)
  - 따라서, 사용자가 해당 도서의 '좋아요'버튼을 클릭하여 서버로 좋아요 기능을 요청보낼 경우 해당 도서의 data가 DB에 새로 생성한 aldin_books 테이블에 존재하는지 확인 후 없다면 도서 data를 삽입
  - 이후 요청한 사용자 id와 해당 도서 id에 대한 좋아요 data를 likes 테이블에 삽입

2. 프론트에서 전달받은 도서 data를 DB에 삽입하기 위해 snake_case로 변환해주는 유틸함수 생성 : camelToSnakeData 함수

### 15) 좋아요 기능, 장바구니 추가 기능 시 도서 데이터를 aladin_books 테이블에 삽입하는 선행 쿼리 수행 후, 본 기능 동작하도록 구현

1. 좋아요 기능, 장바구니 추가 기능 수정
  - 알라딘 오픈 api로 부터 도서 데이터를 받아오고 따로 DB에는 저장하지 않음
  - 사용자가 해당 도서를 좋아요 요청을 하거나 장바구니 추가 기능을 요청할 때 해당 도서 데이터를 먼저 DB에 삽입해야한다.
  - 따라서, aladin_books 테이블에 해당 도서 정보가 존재하지 않는다면 삽입하는 선행쿼리 먼저 수행 후 본 기능 수행하도록 수정

2. 개별 도서 조회 시 좋아요 개수 추출하는 쿼리 추가
  - isLikedService 함수 : 현재 사용자가 로그인한 사용자일 경우, isLiked 필드 값을 true로 설정하여 응답
  - likesCountService 함수 : 해당 도서의 좋아요 수를 추출하는 쿼리 수행
## 버그 해결
### 1) createToken 유틸함수에서 tokenConfig객체의 프로퍼티명 수정
- 문제상황: createToken 유틸함수에서 tokenConfig의 프로퍼티 이름과 전달받은 type의 문자열 값이 일치하지 않게 코드를 작성해서 token을 생성할 때 config가 제대로 들어가지 않는 문제 발생
- 해결: 전달받는 type의 문자열 값과 동일한 프로퍼티 이름으로 수정하여 문제 해결
### 2)  resetRefreshToken 서비스 함수 생성하면서 로그아웃 api 코드를 잘못 수정한 문제로 인한 버그 해결
### 3)  새로운 토큰 재발급 과정에서 보안상 문제가 발생한 경우, DB에 저장되어 있는 refresh token은 제거했으나 쿠키에 저장해둔 refresh token은 삭제하지 않아서 발생한 문제를 해결
- 해결 방법 : 보안상 문제가 발생하여 DB에 저장된 refresh token을 제거한 이후 응답 메세지에 저장된 쿠키의 만료기한을 0으로 설정하여 refresh_token 쿠키 정보를 삭제시킴
### 4) authMiddleware에서 엔드포인트 구하는 방법에 오류가 있어서 해결함
- 해결 방법 : end point 구할 때 '/'단위로 split하여 쪼개진 처음 두 단어를 다시 '/'로 결합하도록 수정